### PR TITLE
refactor(logging): convert interpolated strings to structured logging

### DIFF
--- a/src/Nalix.Codec/DataFrames/PacketBase.cs
+++ b/src/Nalix.Codec/DataFrames/PacketBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -73,10 +73,7 @@ public abstract class PacketBase<[DynamicallyAccessedMembers(DynamicallyAccessed
         if (buffer.Length < required)
         {
             throw new ArgumentException(
-                $"Buffer too small: length={buffer.Length}, required>={required}, type={typeof(TSelf).FullName}. " +
-                $"If you did not manually pass a small buffer, this indicates a Use-After-Free concurrency failure: " +
-                $"the packet size was mutated by another thread. This is typically caused by an orphaned I/O task " +
-                $"missing a CancellationToken.");
+                $"Buffer too small: length={buffer.Length}, required>={required}, type={typeof(TSelf).FullName}. If you did not manually pass a small buffer, this indicates a Use-After-Free concurrency failure: the packet size was mutated by another thread. This is typically caused by an orphaned I/O task missing a CancellationToken.");
         }
 
         try
@@ -91,10 +88,7 @@ public abstract class PacketBase<[DynamicallyAccessedMembers(DynamicallyAccessed
             if (buffer.Length < required)
             {
                 throw new ArgumentException(
-                    $"Buffer too small: length={buffer.Length}, required>={required}, type={typeof(TSelf).FullName}. " +
-                    $"If you did not manually pass a small buffer, this indicates a Use-After-Free concurrency failure: " +
-                    $"the packet size was mutated by another thread. This is typically caused by an orphaned I/O task " +
-                    $"missing a CancellationToken.", ex);
+                    $"Buffer too small: length={buffer.Length}, required>={required}, type={typeof(TSelf).FullName}. If you did not manually pass a small buffer, this indicates a Use-After-Free concurrency failure: the packet size was mutated by another thread. This is typically caused by an orphaned I/O task missing a CancellationToken.", ex);
             }
 
             throw;

--- a/src/Nalix.Codec/DataFrames/PacketRegistry.cs
+++ b/src/Nalix.Codec/DataFrames/PacketRegistry.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -269,8 +269,7 @@ public static class PacketRegistry
         if ((uint)raw.Length < PacketConstants.HeaderSize)
         {
             throw new ArgumentException(
-                $"Raw packet data is too short to contain a valid header. " +
-                $"Expected at least {PacketConstants.HeaderSize} bytes, but got {raw.Length}.", nameof(raw));
+                $"Raw packet data is too short to contain a valid header. Expected at least {PacketConstants.HeaderSize} bytes, but got {raw.Length}.", nameof(raw));
         }
 
         ref readonly PacketHeader header = ref raw.AsHeaderRef();

--- a/src/Nalix.Codec/ProtocolFrames/Control.cs
+++ b/src/Nalix.Codec/ProtocolFrames/Control.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Diagnostics;
@@ -102,6 +102,5 @@ public sealed partial class Control : PacketBase<Control>, IPacketTimestamped, I
 
     /// <inheritdoc/>
     public override string ToString() =>
-        $"Control(Op={this.OpCode}, Len={this.Length}, Flg={this.Flags}, Pri={this.Priority}, " +
-        $"SEQ={this.SequenceId}, Rsn={this.Reason}, Typ={this.Type}, Ts={this.Timestamp}, Mono={this.MonoTicks})";
+        $"Control(Op={this.OpCode}, Len={this.Length}, Flg={this.Flags}, Pri={this.Priority}, SEQ={this.SequenceId}, Rsn={this.Reason}, Typ={this.Type}, Ts={this.Timestamp}, Mono={this.MonoTicks})";
 }

--- a/src/Nalix.Codec/ProtocolFrames/Directive.cs
+++ b/src/Nalix.Codec/ProtocolFrames/Directive.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Diagnostics;
@@ -149,6 +149,5 @@ public sealed partial class Directive : PacketBase<Directive>, IPacketReasoned, 
     /// </summary>
     /// <returns>String describing the Directive packet.</returns>
     public override string ToString()
-        => $"Directive [SequenceId={this.SequenceId}, Type={this.Type}, Reason={this.Reason}, Action={this.Action}, Control={this.Control}, " +
-           $"Arg0={this.Arg0}, Arg1={this.Arg1}, Arg2={this.Arg2}, OpCode={this.OpCode}, Priority={this.Priority}]";
+        => $"Directive [SequenceId={this.SequenceId}, Type={this.Type}, Reason={this.Reason}, Action={this.Action}, Control={this.Control}, Arg0={this.Arg0}, Arg1={this.Arg1}, Arg2={this.Arg2}, OpCode={this.OpCode}, Priority={this.Priority}]";
 }

--- a/src/Nalix.Codec/ProtocolFrames/Handshake.cs
+++ b/src/Nalix.Codec/ProtocolFrames/Handshake.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Diagnostics;
@@ -169,8 +169,7 @@ public sealed partial class Handshake : PacketBase<Handshake>, IFixedSizeSeriali
     /// Returns a compact debug representation of this handshake packet.
     /// </summary>
     public override string ToString()
-        => $"HANDSHAKE(Stage={this.Stage}, OpCode={this.OpCode}, Length={this.Length}, " +
-           $"Flags={this.Flags}, Priority={this.Priority}, SessionToken={this.SessionToken})";
+        => $"HANDSHAKE(Stage={this.Stage}, OpCode={this.OpCode}, Length={this.Length}, Flags={this.Flags}, Priority={this.Priority}, SessionToken={this.SessionToken})";
 
     /// <summary>
     /// Resets this instance for safe pool reuse.

--- a/src/Nalix.Codec/Security/Engine/AeadEngine.cs
+++ b/src/Nalix.Codec/Security/Engine/AeadEngine.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using Nalix.Abstractions.Exceptions;
@@ -89,9 +89,7 @@ public static class AeadEngine
         if (ciphertext.Length < total)
         {
             throw new System.ArgumentException(
-                $"The destination ciphertext buffer is too small for the generated envelope. " +
-                $"Required: {total} bytes, Provided: {ciphertext.Length} bytes, " +
-                $"Missing: {total - ciphertext.Length} bytes.",
+                $"The destination ciphertext buffer is too small for the generated envelope. Required: {total} bytes, Provided: {ciphertext.Length} bytes, Missing: {total - ciphertext.Length} bytes.",
                 nameof(ciphertext));
         }
 

--- a/src/Nalix.Codec/Security/Engine/SymmetricEngine.cs
+++ b/src/Nalix.Codec/Security/Engine/SymmetricEngine.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 //
 // Unified, span-first symmetric cipher engine for Nalix.
@@ -150,9 +150,7 @@ public static class SymmetricEngine
         if (ciphertext.Length < total)
         {
             throw new System.ArgumentException(
-                $"The destination ciphertext buffer is too small for the generated envelope. " +
-                $"Required: {total} bytes, Provided: {ciphertext.Length} bytes, " +
-                $"Missing: {total - ciphertext.Length} bytes.",
+                $"The destination ciphertext buffer is too small for the generated envelope. Required: {total} bytes, Provided: {ciphertext.Length} bytes, Missing: {total - ciphertext.Length} bytes.",
                 nameof(ciphertext));
         }
 

--- a/src/Nalix.Codec/Serialization/FormatterProvider.cs
+++ b/src/Nalix.Codec/Serialization/FormatterProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -676,8 +676,7 @@ public static class FormatterProvider
         if (!TypeMetadata.IsUnmanaged(elem))
         {
             throw new SerializationFailureException(
-                $"MemoryFormatter only supports unmanaged element types. " +
-                $"'{elem.Name}' is not unmanaged.");
+                $"MemoryFormatter only supports unmanaged element types. '{elem.Name}' is not unmanaged.");
         }
 
         return def == typeof(Memory<>)

--- a/src/Nalix.Codec/Serialization/Formatters/Primitives/ValueTupleFormatter.cs
+++ b/src/Nalix.Codec/Serialization/Formatters/Primitives/ValueTupleFormatter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using Nalix.Environment.Memory;
@@ -110,8 +110,7 @@ internal sealed class ValueTupleFormatter<
     [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)] T4> : IFormatter<(T1, T2, T3, T4)>
 {
     private static string DebuggerDisplay =>
-        $"ValueTupleFormatter<{typeof(T1).Name}, {typeof(T2).Name}, " +
-        $"{typeof(T3).Name}, {typeof(T4).Name}>";
+        $"ValueTupleFormatter<{typeof(T1).Name}, {typeof(T2).Name}, {typeof(T3).Name}, {typeof(T4).Name}>";
 
     private readonly IFormatter<T1> _f1 = FormatterProvider.Get<T1>();
     private readonly IFormatter<T2> _f2 = FormatterProvider.Get<T2>();
@@ -172,8 +171,7 @@ internal sealed class ValueTupleFormatter<
     : IFormatter<(T1, T2, T3, T4, T5)>
 {
     private static string DebuggerDisplay =>
-        $"ValueTupleFormatter<{typeof(T1).Name}, {typeof(T2).Name}, {typeof(T3).Name}, " +
-        $"{typeof(T4).Name}, {typeof(T5).Name}>";
+        $"ValueTupleFormatter<{typeof(T1).Name}, {typeof(T2).Name}, {typeof(T3).Name}, {typeof(T4).Name}, {typeof(T5).Name}>";
 
     private readonly IFormatter<T1> _f1 = FormatterProvider.Get<T1>();
     private readonly IFormatter<T2> _f2 = FormatterProvider.Get<T2>();

--- a/src/Nalix.Environment/Configuration/ConfigurationManager.cs
+++ b/src/Nalix.Environment/Configuration/ConfigurationManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -769,8 +769,7 @@ public sealed class ConfigurationManager : IDisposable
             if (!string.Equals(normalizedPath, Path.GetFullPath(_baseConfigDirectory), StringComparison.OrdinalIgnoreCase))
             {
                 throw new InternalErrorException(
-                    $"Configuration file path '{pathToValidate}' is outside the allowed " +
-                    $"configuration directory '{_baseConfigDirectory}'.");
+                    $"Configuration file path '{pathToValidate}' is outside the allowed configuration directory '{_baseConfigDirectory}'.");
             }
         }
     }

--- a/src/Nalix.Environment/Options/FragmentOptions.cs
+++ b/src/Nalix.Environment/Options/FragmentOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -88,16 +88,14 @@ public sealed partial class FragmentOptions : ConfigurationLoader, IValidatableC
         if (maxChunkCount > ushort.MaxValue)
         {
             throw new ValidationException(
-                $"MaxChunkSize={this.MaxChunkSize} can produce {maxChunkCount} chunks for MaxPayloadSize={this.MaxPayloadSize}, " +
-                $"which exceeds the {ushort.MaxValue}-chunk wire header limit.");
+                $"MaxChunkSize={this.MaxChunkSize} can produce {maxChunkCount} chunks for MaxPayloadSize={this.MaxPayloadSize}, which exceeds the {ushort.MaxValue}-chunk wire header limit.");
         }
 
         int maxChunkFrameSize = PacketConstants.HeaderSize + FragmentHeader.WireSize + this.MaxChunkSize;
         if (maxChunkFrameSize > ushort.MaxValue)
         {
             throw new ValidationException(
-                $"MaxChunkSize={this.MaxChunkSize} produces a fragment frame of {maxChunkFrameSize} bytes, " +
-                $"which exceeds the {ushort.MaxValue}-byte wire header limit.");
+                $"MaxChunkSize={this.MaxChunkSize} produces a fragment frame of {maxChunkFrameSize} bytes, which exceeds the {ushort.MaxValue}-byte wire header limit.");
         }
     }
 }

--- a/src/Nalix.Framework/Injection/InstanceManager.Activators.cs
+++ b/src/Nalix.Framework/Injection/InstanceManager.Activators.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -494,9 +494,7 @@ public sealed partial class InstanceManager
 
         // 3. No match → detailed error
         throw new InternalErrorException(
-            $"Cannot auto-inject '{type.Name}': no public constructor found " +
-            $"where all parameters are resolvable from InstanceManager cache. " +
-            $"Registered types: [{string.Join(", ", this.GetRegisteredTypeNames())}].");
+            $"Cannot auto-inject '{type.Name}': no public constructor found where all parameters are resolvable from InstanceManager cache. Registered types: [{string.Join(", ", this.GetRegisteredTypeNames())}].");
     }
 
     /// <summary>

--- a/src/Nalix.Hosting/Protocols/DefaultFrameProcessor.cs
+++ b/src/Nalix.Hosting/Protocols/DefaultFrameProcessor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -151,7 +151,7 @@ public sealed class DefaultFrameProcessor : IFrameProcessor
             {
                 if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
                 {
-                    _logger.LogTrace($"[NW.{nameof(TcpListenerBase)}:{nameof(ProcessFrame)}] {ex.Message}");
+                    _logger.LogTrace(ex, "[NW.TcpListenerBase:ProcessFrame]");
                 }
             }
             else

--- a/src/Nalix.Logging/Extensions/NLogixFx.Internal.cs
+++ b/src/Nalix.Logging/Extensions/NLogixFx.Internal.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -43,12 +43,7 @@ public static partial class NLogixFx
         string callerFilePath, int callerLineNumber)
     {
         return
-            $"{Sep}\n" +
-            $"Source     : {sourceName ?? "None"}\n" +
-            $"Caller     : {callerMemberName} ({callerFilePath}:{callerLineNumber})\n" +
-            $"Data       : {FORMAT_EXTENDED_DATA(extendedData)}\n" +
-            $"Message    : {message}\n" +
-            $"{Sep}\n";
+            $"{Sep}\nSource     : {sourceName ?? "None"}\nCaller     : {callerMemberName} ({callerFilePath}:{callerLineNumber})\nData       : {FORMAT_EXTENDED_DATA(extendedData)}\nMessage    : {message}\n{Sep}\n";
     }
 
     private static string FORMAT_EXTENDED_DATA(object? extendedData)

--- a/src/Nalix.Logging/NLogixDistributor.cs
+++ b/src/Nalix.Logging/NLogixDistributor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -182,8 +182,7 @@ public sealed class NLogixDistributor : INLogixDistributor
             // Log to debug output at minimum
 #if DEBUG
             Debug.WriteLine(
-                $"[{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}] ERROR publishing to " +
-                $"{target.GetType().Name}: {exception.Message}");
+                $"[{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss}] ERROR publishing to {target.GetType().Name}: {exception.Message}");
 #endif
 
             // Check if target implements error handling

--- a/src/Nalix.Network/Connections/Connection.Hub.cs
+++ b/src/Nalix.Network/Connections/Connection.Hub.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -270,7 +270,7 @@ public sealed class ConnectionHub : IConnectionHub
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.LogTrace($"[NW.{nameof(ConnectionHub)}:{nameof(BroadcastAsync)}] broadcast-skip total=0");
+                _logger.LogTrace("[NW.ConnectionHub:BroadcastAsync] broadcast-skip total=0");
             }
 
             return;
@@ -295,7 +295,7 @@ public sealed class ConnectionHub : IConnectionHub
 
         if (measureLatency && logger != null)
         {
-            logger.LogInformation($"[PERF.NW.BroadcastAsync] total={connections.Length}, latency={scope.GetElapsedMilliseconds():F3} ms");
+            logger.LogInformation("[PERF.NW.BroadcastAsync] total={Total}, latency={LatencyMs} ms", connections.Length, scope.GetElapsedMilliseconds());
         }
     }
 
@@ -344,7 +344,7 @@ public sealed class ConnectionHub : IConnectionHub
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Information))
         {
-            _logger.LogInformation($"[NW.{nameof(ConnectionHub)}:{nameof(Dispose)}] disposed");
+            _logger.LogInformation("[NW.ConnectionHub:Dispose] disposed");
         }
     }
 
@@ -474,8 +474,7 @@ public sealed class ConnectionHub : IConnectionHub
             {
                 if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug(
-                        $"[NW.{nameof(ConnectionHub)}:{nameof(RegisterConnection)}] register-dup id={connection.ID}");
+                    _logger.LogDebug("[NW.ConnectionHub:RegisterConnection] register-dup id={ConnectionId}", connection.ID);
                 }
 
                 return RegisterResult.Duplicate;
@@ -485,14 +484,12 @@ public sealed class ConnectionHub : IConnectionHub
 
             if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.LogTrace(
-                    $"[NW.{nameof(ConnectionHub)}:{nameof(RegisterConnection)}] register id={connection.ID} total={_registry.Count}");
+                _logger.LogTrace("[NW.ConnectionHub:RegisterConnection] register id={ConnectionId} total={RegistryCount}", connection.ID, _registry.Count);
             }
 
             if (measureLatency && _logger != null)
             {
-                _logger.LogInformation(
-                    $"[PERF.NW.RegisterConnection] id={connection.ID}, latency={scope.GetElapsedMilliseconds():F3} ms");
+                _logger.LogInformation("[PERF.NW.RegisterConnection] id={ConnectionId}, latency={LatencyMs} ms", connection.ID, scope.GetElapsedMilliseconds());
             }
 
             return RegisterResult.Success;
@@ -519,8 +516,7 @@ public sealed class ConnectionHub : IConnectionHub
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug(
-                    $"[NW.{nameof(ConnectionHub)}:{nameof(UnregisterConnection)}] unregister-miss id={connection.ID}");
+                _logger.LogDebug("[NW.ConnectionHub:UnregisterConnection] unregister-miss id={ConnectionId}", connection.ID);
             }
 
             return false;
@@ -540,7 +536,7 @@ public sealed class ConnectionHub : IConnectionHub
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[NW.{nameof(ConnectionHub)}:{nameof(UnregisterConnection)}] event-error id={removedConnection.ID}");
+                _logger.LogError(ex, "[NW.ConnectionHub:UnregisterConnection] event-error id={RemovedConnectionID}", removedConnection.ID);
             }
         }
 
@@ -558,20 +554,18 @@ public sealed class ConnectionHub : IConnectionHub
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[NW.{nameof(ConnectionHub)}:{nameof(UnregisterConnection)}] dispose-error id={removedConnection.ID}");
+                _logger.LogError(ex, "[NW.ConnectionHub:UnregisterConnection] dispose-error id={RemovedConnectionID}", removedConnection.ID);
             }
         }
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
         {
-            _logger.LogTrace(
-                $"[NW.{nameof(ConnectionHub)}:{nameof(UnregisterConnection)}] unregister id={removedConnection.ID} total={_registry.Count}");
+            _logger.LogTrace("[NW.ConnectionHub:UnregisterConnection] unregister id={RemovedConnectionID} total={RegistryCount}", removedConnection.ID, _registry.Count);
         }
 
         if (measureLatency && _logger != null)
         {
-            _logger.LogInformation(
-                $"[PERF.NW.UnregisterConnection] id={removedConnection.ID}, latency={scope.GetElapsedMilliseconds():F3} ms");
+            _logger.LogInformation("[PERF.NW.UnregisterConnection] id={RemovedConnectionID}, latency={LatencyMs} ms", removedConnection.ID, scope.GetElapsedMilliseconds());
         }
 
         return true;
@@ -653,8 +647,7 @@ public sealed class ConnectionHub : IConnectionHub
                 {
                     if (_logger != null && _logger.IsEnabled(LogLevel.Error))
                     {
-                        _logger.LogError(ex,
-                            $"[NW.{nameof(ConnectionHub)}:{operationName}] send-failure id={connection.ID}");
+                        _logger.LogError(ex, "[NW.ConnectionHub:{Operation}] send-failure id={ConnectionId}", operationName, connection.ID);
                     }
                 }
             }
@@ -672,7 +665,7 @@ public sealed class ConnectionHub : IConnectionHub
             {
                 if (_logger != null && _logger.IsEnabled(LogLevel.Information))
                 {
-                    _logger.LogInformation($"[NW.{nameof(ConnectionHub)}:{operationName}] broadcast-cancel");
+                    _logger.LogInformation("[NW.ConnectionHub:{Operation}] broadcast-cancel", operationName);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
@@ -713,8 +706,7 @@ public sealed class ConnectionHub : IConnectionHub
             IConnection owner = owners[i];
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(exception,
-                    $"[NW.{nameof(ConnectionHub)}:{operationName}] send-failure id={owner.ID}");
+                _logger.LogError(exception, "[NW.ConnectionHub:{Operation}] send-failure id={OwnerID}", operationName, owner.ID);
             }
         }
     }
@@ -757,8 +749,7 @@ public sealed class ConnectionHub : IConnectionHub
                 {
                     if (_logger != null && _logger.IsEnabled(LogLevel.Error))
                     {
-                        _logger.LogError(ex,
-                            $"[NW.{nameof(ConnectionHub)}:{nameof(BroadcastBatchedAsync)}] send-failure id={connection.ID}");
+                        _logger.LogError(ex, "[NW.ConnectionHub:BroadcastBatchedAsync] send-failure id={ConnectionId}", connection.ID);
                     }
                 }
 
@@ -805,7 +796,7 @@ public sealed class ConnectionHub : IConnectionHub
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Information))
             {
-                _logger.LogInformation($"[NW.{nameof(ConnectionHub)}:{operationName}] broadcast-cancel");
+                _logger.LogInformation("[NW.ConnectionHub:{Operation}] broadcast-cancel", operationName);
             }
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))

--- a/src/Nalix.Network/Connections/Connection.cs
+++ b/src/Nalix.Network/Connections/Connection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -124,7 +124,7 @@ public sealed partial class Connection :
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
         {
-            _logger.LogTrace($"[NW.{nameof(Connection)}] created remote={this.NetworkEndpoint} id={this.ID}");
+            _logger.LogTrace("[NW.Connection] created remote={RemoteEndpoint} id={ConnectionId}", this.NetworkEndpoint, this.ID);
         }
     }
 
@@ -376,7 +376,7 @@ public sealed partial class Connection :
                                 {
                                     if (_logger != null && _logger.IsEnabled(LogLevel.Error))
                                     {
-                                        _logger.LogError(handlerEx, $"[NW.{nameof(Connection)}:{nameof(this.Dispose)}] close-handler-error");
+                                        _logger.LogError(handlerEx, "[NW.Connection:this.Dispose] close-handler-error");
                                     }
                                 }
                             }
@@ -392,7 +392,7 @@ public sealed partial class Connection :
             {
                 if (_logger != null && _logger.IsEnabled(LogLevel.Error))
                 {
-                    _logger.LogError(ex, $"[NW.{nameof(Connection)}:{nameof(this.Dispose)}] close-event-error msg={ex.Message}");
+                    _logger.LogError(ex, "[NW.Connection:this.Dispose] close-event-error msg=");
                 }
             }
             finally
@@ -491,7 +491,7 @@ public sealed partial class Connection :
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[NW.{nameof(Connection)}:{nameof(this.Dispose)}] {component}-dispose-error msg={ex.Message}");
+                _logger.LogError(ex, "[NW.Connection:this.Dispose] {Component}-dispose-error msg=", component);
             }
         }
     }
@@ -636,7 +636,7 @@ public sealed partial class Connection :
                     {
                         if (self._logger != null && self._logger.IsEnabled(LogLevel.Error))
                         {
-                            self._logger.LogError(handlerEx, $"[NW.{nameof(Connection)}:{nameof(OnCloseEventDispatchBridge)}] close-handler-error");
+                            self._logger.LogError(handlerEx, "[NW.Connection:OnCloseEventDispatchBridge] close-handler-error");
                         }
                     }
                 }

--- a/src/Nalix.Network/Connections/PassthroughConnection.cs
+++ b/src/Nalix.Network/Connections/PassthroughConnection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -326,8 +326,7 @@ public sealed class PassthroughConnection : IConnection, TimingWheel.ITimeoutTra
                         {
                             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
                             {
-                                _logger.LogError(ex,
-                                    $"[NW.{nameof(PassthroughConnection)}:{nameof(Dispose)}] close-handler-error");
+                                _logger.LogError(ex, "[NW.PassthroughConnection:Dispose] close-handler-error");
                             }
                         }
                     }
@@ -342,8 +341,7 @@ public sealed class PassthroughConnection : IConnection, TimingWheel.ITimeoutTra
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex,
-                    $"[NW.{nameof(PassthroughConnection)}:{nameof(Dispose)}] close-event-error");
+                _logger.LogError(ex, "[NW.PassthroughConnection:Dispose] close-event-error");
             }
         }
 

--- a/src/Nalix.Network/Connections/WebSocketConnection.cs
+++ b/src/Nalix.Network/Connections/WebSocketConnection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -94,7 +94,7 @@ public sealed class WebSocketConnection : IConnection, IConnectionErrorTracked, 
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
         {
-            _logger.LogTrace($"[NW.{nameof(WebSocketConnection)}] created remote={this.NetworkEndpoint} id={this.ID}");
+            _logger.LogTrace("[NW.WebSocketConnection] created remote={RemoteEndpoint} id={ConnectionId}", this.NetworkEndpoint, this.ID);
         }
     }
 
@@ -239,7 +239,7 @@ public sealed class WebSocketConnection : IConnection, IConnectionErrorTracked, 
 
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning($"[NW.{nameof(WebSocketConnection)}] receive throttle triggered remote={this.NetworkEndpoint}");
+                _logger.LogWarning("[NW.WebSocketConnection] receive throttle triggered remote={RemoteEndpoint}", this.NetworkEndpoint);
             }
             return;
         }
@@ -311,7 +311,7 @@ public sealed class WebSocketConnection : IConnection, IConnectionErrorTracked, 
     {
         if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug($"[NW.{nameof(WebSocketConnection)}] disconnect request id={this.ID} remote={this.NetworkEndpoint} reason={reason}");
+            _logger.LogDebug("[NW.WebSocketConnection] disconnect request id={ConnectionId} remote={RemoteEndpoint} reason={Reason}", this.ID, this.NetworkEndpoint, reason);
         }
         this.Dispose();
     }
@@ -353,7 +353,7 @@ public sealed class WebSocketConnection : IConnection, IConnectionErrorTracked, 
                 {
                     if (_logger != null && _logger.IsEnabled(LogLevel.Error))
                     {
-                        _logger.LogError(ex, $"[NW.{nameof(WebSocketConnection)}] Close event error");
+                        _logger.LogError(ex, "[NW.WebSocketConnection] Close event error");
                     }
                 }
                 finally

--- a/src/Nalix.Network/Internal/Security/NetworkAccessList.cs
+++ b/src/Nalix.Network/Internal/Security/NetworkAccessList.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
@@ -99,7 +99,7 @@ internal sealed class NetworkAccessList
 
         if (networks.Count > 0 && _logger != null && _logger.IsEnabled(LogLevel.Information))
         {
-            _logger.LogInformation($"[NW.NetworkAccessList] Loaded {networks.Count} trusted proxies from disk.");
+            _logger.LogInformation("[NW.NetworkAccessList] Loaded {NetworksCount} trusted proxies from disk.", networks.Count);
         }
     }
 
@@ -132,7 +132,7 @@ internal sealed class NetworkAccessList
 
         if (networks.Count > 0 && _logger != null && _logger.IsEnabled(LogLevel.Information))
         {
-            _logger.LogInformation($"[NW.NetworkAccessList] Loaded {networks.Count} blacklisted IP/networks from disk (single IPs: {_blacklistedIps.Count}, CIDR networks: {_blacklistedNetworks.Count}).");
+            _logger.LogInformation("[NW.NetworkAccessList] Loaded {NetworksCount} blacklisted IP/networks from disk (single IPs: {BlacklistedIpsCount}, CIDR networks: {BlacklistedNetworksCount}).", networks.Count, _blacklistedIps.Count, _blacklistedNetworks.Count);
         }
     }
 

--- a/src/Nalix.Network/Internal/Security/NetworkBanRepository.cs
+++ b/src/Nalix.Network/Internal/Security/NetworkBanRepository.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -71,7 +71,7 @@ internal sealed class NetworkBanRepository
 
         if (records.Count > 0 && _logger != null && _logger.IsEnabled(LogLevel.Information))
         {
-            _logger.LogInformation($"[NW.NetworkBanRepository] Loaded {records.Count} persisted bans.");
+            _logger.LogInformation("[NW.NetworkBanRepository] Loaded {RecordsCount} persisted bans.", records.Count);
         }
     }
 
@@ -124,7 +124,7 @@ internal sealed class NetworkBanRepository
 
                 if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug($"[NW.NetworkBanRepository] Persisted {snapshot.Count} bans to disk.");
+                    _logger.LogDebug("[NW.NetworkBanRepository] Persisted {SnapshotCount} bans to disk.", snapshot.Count);
                 }
             }
         }
@@ -134,7 +134,7 @@ internal sealed class NetworkBanRepository
             _ = Interlocked.Exchange(ref _persistenceDirty, 1);
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[NW.NetworkBanRepository] failed to save banned ips.");
+                _logger.LogError(ex, "[NW.NetworkBanRepository] failed to save banned ips.");
             }
         }
     }

--- a/src/Nalix.Network/Internal/Security/ThrottledLogGate.cs
+++ b/src/Nalix.Network/Internal/Security/ThrottledLogGate.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -73,12 +73,11 @@ internal static class ThrottledLogGate
         {
             if (suppressed > 0)
             {
-                logger.LogWarning(
-                    $"[NW.ConnectionGuard] DDoS-detected ip={address} (+{suppressed} suppressed-in-last={TimeSpan.FromTicks(windowTicks).TotalSeconds:F0}s)");
+                logger.LogWarning("[NW.ConnectionGuard] DDoS-detected ip={Address} (+{Suppressed} suppressed-in-last={TimeSpanFromTickswindowTicksTotalSeconds}s)", address, suppressed, TimeSpan.FromTicks(windowTicks).TotalSeconds);
             }
             else
             {
-                logger.LogWarning($"[NW.ConnectionGuard] DDoS-detected ip={address}");
+                logger.LogWarning("[NW.ConnectionGuard] DDoS-detected ip={Address}", address);
             }
         }
     }
@@ -98,7 +97,8 @@ internal static class ThrottledLogGate
 
             if (logger != null && logger.IsEnabled(LogLevel.Trace))
             {
-                logger.LogTrace($"[NW.ConnectionGuard] banned-reject ip={address} until={bannedUntil:HH:mm:ss}{suffix}");
+                string bannedTime = bannedUntil.ToString("HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture);
+                logger.LogTrace("[NW.ConnectionGuard] banned-reject ip={Address} until={BannedUntil}{Suffix}", address, bannedTime, suffix);
             }
         }
     }

--- a/src/Nalix.Network/Internal/Time/TimingWheel.cs
+++ b/src/Nalix.Network/Internal/Time/TimingWheel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -312,9 +312,7 @@ internal sealed class TimingWheel : IActivatable
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Information))
         {
-            _logger.LogInformation(
-                $"[NW.{nameof(TimingWheel)}:{nameof(Activate)}] activated (ref={_activeListeners}) " +
-                $"wheelsize={_wheelSize} tick={_tickMs}ms idle={_idleTimeoutMs}ms mask={_useMask}");
+            _logger.LogInformation("[NW.TimingWheel:Activate] activated (ref={ActiveListeners}) wheelsize={WheelSize} tick={TickMs}ms idle={IdleTimeoutMs}ms mask={UseMask}", _activeListeners, _wheelSize, _tickMs, _idleTimeoutMs, _useMask);
         }
     }
 
@@ -366,18 +364,14 @@ internal sealed class TimingWheel : IActivatable
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug(
-                    $"[NW.{nameof(TimingWheel)}:{nameof(Deactivate)}] " +
-                    $"cts-cancel-ignored reason={ex.GetType().Name}");
+                _logger.LogDebug(ex, "[NW.TimingWheel:Deactivate] cts-cancel-ignored reason={ExceptionType}", ex.GetType().Name);
             }
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning(ex,
-                    $"[NW.{nameof(TimingWheel)}:{nameof(Deactivate)}] " +
-                    $"cts-cancel-failed");
+                _logger.LogWarning(ex, "[NW.TimingWheel:Deactivate] cts-cancel-failed");
             }
         }
 
@@ -389,18 +383,14 @@ internal sealed class TimingWheel : IActivatable
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug(
-                    $"[NW.{nameof(TimingWheel)}:{nameof(Deactivate)}] " +
-                    $"cts-dispose-ignored reason={ex.GetType().Name}");
+                _logger.LogDebug(ex, "[NW.TimingWheel:Deactivate] cts-dispose-ignored reason={ExceptionType}", ex.GetType().Name);
             }
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning(ex,
-                    $"[NW.{nameof(TimingWheel)}:{nameof(Deactivate)}] " +
-                    $"cts-dispose-failed");
+                _logger.LogWarning(ex, "[NW.TimingWheel:Deactivate] cts-dispose-failed");
             }
         }
 
@@ -412,9 +402,7 @@ internal sealed class TimingWheel : IActivatable
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning(ex,
-                    $"[NW.{nameof(TimingWheel)}:{nameof(Deactivate)}] " +
-                    $"worker-dispose-failed");
+                _logger.LogWarning(ex, "[NW.TimingWheel:Deactivate] worker-dispose-failed");
             }
         }
 
@@ -422,7 +410,7 @@ internal sealed class TimingWheel : IActivatable
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Information))
         {
-            _logger.LogInformation($"[NW.{nameof(TimingWheel)}:{nameof(Deactivate)}] deactivated");
+            _logger.LogInformation("[NW.TimingWheel:Deactivate] deactivated");
         }
     }
 
@@ -675,9 +663,7 @@ internal sealed class TimingWheel : IActivatable
                         {
                             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                             {
-                                _logger.LogDebug(
-                                $"[NW.{nameof(TimingWheel)}] timeout " +
-                                $"remote={connection.NetworkEndpoint?.Address} idle={idleMs}ms");
+                                _logger.LogDebug("[NW.TimingWheel] timeout remote={ConnectionNetworkEndpointAddress} idle={IdleMs}ms", connection.NetworkEndpoint?.Address, idleMs);
                             }
 
                             try
@@ -688,9 +674,7 @@ internal sealed class TimingWheel : IActivatable
                             {
                                 if (_logger != null && _logger.IsEnabled(LogLevel.Error))
                                 {
-                                    _logger.LogError(ex,
-                                        $"[NW.{nameof(TimingWheel)}] close-error " +
-                                        $"remote={connection.NetworkEndpoint?.Address}");
+                                    _logger.LogError(ex, "[NW.TimingWheel] close-error remote={ConnectionNetworkEndpointAddress}", connection.NetworkEndpoint?.Address);
                                 }
                             }
 
@@ -733,7 +717,7 @@ internal sealed class TimingWheel : IActivatable
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[NW.{nameof(TimingWheel)}] loop-error");
+                _logger.LogError(ex, "[NW.TimingWheel] loop-error");
             }
         }
     }

--- a/src/Nalix.Network/Internal/Transport/AsyncCallback.cs
+++ b/src/Nalix.Network/Internal/Transport/AsyncCallback.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -156,7 +156,7 @@ internal static class AsyncCallback
 #if DEBUG
             if (s_logger != null && s_logger.IsEnabled(LogLevel.Trace))
             {
-                s_logger.LogTrace($"[NW.{nameof(AsyncCallback)}:{nameof(Invoke)}] callback-null skipping");
+                s_logger.LogTrace("[NW.AsyncCallback:Invoke] callback-null skipping");
             }
 #endif
             return false;

--- a/src/Nalix.Network/Internal/Transport/SocketConnection.Receive.VarInt.cs
+++ b/src/Nalix.Network/Internal/Transport/SocketConnection.Receive.VarInt.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -43,9 +43,7 @@ internal sealed partial class SocketConnection
                     {
                         if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
                         {
-                            _logger.LogTrace(
-                                $"[NW.{nameof(SocketConnection)}:{nameof(SAEA_RECEIVE_LOOP_VARINT_ASYNC)}] " +
-                                $"varint-invalid-size-drop size={payloadLen} max={_maxVarIntPayloadSize} ep={_endpointString}");
+                            _logger.LogTrace("[NW.SocketConnection:SAEA_RECEIVE_LOOP_VARINT_ASYNC] varint-invalid-size-drop size={PayloadLength} max={MaxVarIntPayloadSize} ep={Endpoint}", payloadLen, _maxVarIntPayloadSize, _endpointString);
                         }
 
                         throw new InternalErrorException($"VarInt payload size {payloadLen} is invalid or exceeds the maximum allowed size of {_maxVarIntPayloadSize}.");
@@ -114,18 +112,14 @@ internal sealed partial class SocketConnection
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.LogTrace(
-                    $"[NW.{nameof(SocketConnection)}:{nameof(SAEA_RECEIVE_LOOP_VARINT_ASYNC)}] " +
-                    $"ended (peer closed/shutdown) ep={_owner?.NetworkEndpoint.Address}");
+                _logger.LogTrace("[NW.SocketConnection:SAEA_RECEIVE_LOOP_VARINT_ASYNC] ended (peer closed/shutdown) ep={OwnerNetworkEndpointAddress}", _owner?.NetworkEndpoint.Address);
             }
         }
         catch (OperationCanceledException)
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.LogTrace(
-                    $"[NW.{nameof(SocketConnection)}:{nameof(SAEA_RECEIVE_LOOP_VARINT_ASYNC)}] " +
-                    $"cancelled ep={_owner?.NetworkEndpoint.Address}");
+                _logger.LogTrace("[NW.SocketConnection:SAEA_RECEIVE_LOOP_VARINT_ASYNC] cancelled ep={OwnerNetworkEndpointAddress}", _owner?.NetworkEndpoint.Address);
             }
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
@@ -164,9 +158,7 @@ internal sealed partial class SocketConnection
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.LogTrace(
-                    $"[NW.{nameof(SocketConnection)}:{nameof(PROCESS_VARINT_FRAME_FROM_BUFFER)}] " +
-                    $"sink-rejected-frame-drop size={payloadLen} ep={_endpointString}");
+                _logger.LogTrace("[NW.SocketConnection:PROCESS_VARINT_FRAME_FROM_BUFFER] sink-rejected-frame-drop size={PayloadLength} ep={Endpoint}", payloadLen, _endpointString);
             }
 
             lease.Dispose();
@@ -175,9 +167,7 @@ internal sealed partial class SocketConnection
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
         {
-            _logger.LogTrace(
-                $"[NW.{nameof(SocketConnection)}:{nameof(PROCESS_VARINT_FRAME_FROM_BUFFER)}] " +
-                $"accepted payload={payloadLen} ep={_endpointString}");
+            _logger.LogTrace("[NW.SocketConnection:PROCESS_VARINT_FRAME_FROM_BUFFER] accepted payload={PayloadLength} ep={Endpoint}", payloadLen, _endpointString);
         }
     }
 }

--- a/src/Nalix.Network/Internal/Transport/SocketConnection.Send.VarInt.cs
+++ b/src/Nalix.Network/Internal/Transport/SocketConnection.Send.VarInt.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -38,7 +38,7 @@ internal sealed partial class SocketConnection
 #if DEBUG
                 if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug($"[NW.{nameof(SocketConnection)}:{nameof(Send)}] stackalloc varint len={data.Length} ep={_socket.RemoteEndPoint}");
+                    _logger.LogDebug("[NW.SocketConnection:Send] stackalloc varint len={Length} ep={RemoteEndpoint}", data.Length, _socket.RemoteEndPoint);
                 }
 #endif
                 Span<byte> frameS = stackalloc byte[totalLength];

--- a/src/Nalix.Network/Internal/Transport/SocketConnection.Send.cs
+++ b/src/Nalix.Network/Internal/Transport/SocketConnection.Send.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -73,9 +73,7 @@ internal sealed partial class SocketConnection
 #if DEBUG
                 if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug(
-                        $"[NW.{nameof(SocketConnection)}:{nameof(Send)}] " +
-                        $"stackalloc len={data.Length} ep={_socket.RemoteEndPoint}");
+                    _logger.LogDebug("[NW.SocketConnection:Send] stackalloc len={Length} ep={RemoteEndpoint}", data.Length, _socket.RemoteEndPoint);
                 }
 #endif
                 Span<byte> frameS = stackalloc byte[totalLength];
@@ -85,9 +83,7 @@ internal sealed partial class SocketConnection
                 if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                 {
                     Span<byte> payloadSpan = frameS.Slice(HeaderSize, data.Length);
-                    _logger.LogDebug(
-                        $"[NW.{nameof(SocketConnection)}:{nameof(Send)}] " +
-                        $"sending frame totalLen={totalLength} payload={FORMAT_FRAME_FOR_LOG(payloadSpan)} ep={_socket.RemoteEndPoint}");
+                    _logger.LogDebug("[NW.SocketConnection:Send] sending frame totalLen={TotalLength} payload={FORMATFRAMEFORLOGpayloadSpan} ep={RemoteEndpoint}", totalLength, FORMAT_FRAME_FOR_LOG(payloadSpan), _socket.RemoteEndPoint);
                 }
 #endif
 
@@ -102,9 +98,7 @@ internal sealed partial class SocketConnection
 #if DEBUG
                             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                             {
-                                _logger.LogDebug(
-                                    $"[NW.{nameof(SocketConnection)}:{nameof(Send)}] " +
-                                    $"stackalloc peer-closed ep={_socket.RemoteEndPoint}");
+                                _logger.LogDebug("[NW.SocketConnection:Send] stackalloc peer-closed ep={RemoteEndpoint}", _socket.RemoteEndPoint);
                             }
 #endif
                             this.CANCEL_RECEIVE_ONCE();
@@ -127,8 +121,7 @@ internal sealed partial class SocketConnection
 #if DEBUG
                     if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                     {
-                        _logger.LogDebug($"[NW.{nameof(SocketConnection)}:{nameof(Send)}] " +
-                                      $"stackalloc-benign-disconnect ep={_endpointString} ex={ex.GetType().Name}");
+                        _logger.LogDebug(ex, "[NW.SocketConnection:Send] stackalloc-benign-disconnect ep={Endpoint} ex={ExceptionType}", _endpointString, ex.GetType().Name);
                     }
 #endif
                 }
@@ -155,9 +148,7 @@ internal sealed partial class SocketConnection
 #if DEBUG
             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug(
-                    $"[NW.{nameof(SocketConnection)}:{nameof(Send)}] " +
-                    $"pooled len={data.Length} ep={_socket.RemoteEndPoint}");
+                _logger.LogDebug("[NW.SocketConnection:Send] pooled len={Length} ep={RemoteEndpoint}", data.Length, _socket.RemoteEndPoint);
             }
 #endif
             BinaryPrimitives.WriteUInt16LittleEndian(MemoryExtensions.AsSpan(heapBuf), (ushort)totalLength);
@@ -167,10 +158,7 @@ internal sealed partial class SocketConnection
             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
             {
                 Span<byte> payloadSpan = MemoryExtensions.AsSpan(heapBuf, HeaderSize, data.Length);
-                _logger.LogDebug(
-                    $"[NW.{nameof(SocketConnection)}:{nameof(Send)}] " +
-                    $"sending frame totalLen={totalLength} payload={FORMAT_FRAME_FOR_LOG(payloadSpan)} " +
-                    $"ep={_socket.RemoteEndPoint}");
+                _logger.LogDebug("[NW.SocketConnection:Send] sending frame totalLen={TotalLength} payload={FORMATFRAMEFORLOGpayloadSpan} ep={RemoteEndpoint}", totalLength, FORMAT_FRAME_FOR_LOG(payloadSpan), _socket.RemoteEndPoint);
             }
 #endif
 

--- a/src/Nalix.Network/Internal/Transport/SocketConnection.cs
+++ b/src/Nalix.Network/Internal/Transport/SocketConnection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -202,7 +202,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug($"[NW.{nameof(SocketConnection)}:{nameof(BeginReceive)}] skip \u2014 already disposed ep={_endpointString}");
+                _logger.LogDebug("[NW.SocketConnection:BeginReceive] skip \u2014 already disposed ep={Endpoint}", _endpointString);
             }
 #endif
             return;
@@ -214,7 +214,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug($"[NW.{nameof(SocketConnection)}:{nameof(BeginReceive)}] skip \u2014 already started ep={_endpointString}");
+                _logger.LogDebug("[NW.SocketConnection:BeginReceive] skip \u2014 already started ep={Endpoint}", _endpointString);
             }
 #endif
             return;
@@ -231,7 +231,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
         if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug($"[NW.{nameof(SocketConnection)}:{nameof(BeginReceive)}] saea-receive-loop started ep={_endpointString} framing={_framing}");
+            _logger.LogDebug("[NW.SocketConnection:BeginReceive] saea-receive-loop started ep={Endpoint} framing={Framing}", _endpointString, _framing);
         }
 #endif
 
@@ -289,11 +289,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override string ToString()
-        => $"FramedSocketConnection (Client={_endpointString}, " +
-           $"Disposed={Volatile.Read(ref _disposed) != 0}, " +
-           $"UpTime={this.Uptime}ms, LastPing={this.LastPingTime}ms, " +
-           $"PendingPackets={(_sink as SocketEventBridge)?.PendingPackets ?? 0}, " +
-           $"OpenFragmentStreams={Volatile.Read(ref _openFragmentStreams)}.";
+        => $"FramedSocketConnection (Client={_endpointString}, Disposed={Volatile.Read(ref _disposed) != 0}, UpTime={this.Uptime}ms, LastPing={this.LastPingTime}ms, PendingPackets={(_sink as SocketEventBridge)?.PendingPackets ?? 0}, OpenFragmentStreams={Volatile.Read(ref _openFragmentStreams)}.";
 
     #endregion Dispose Pattern
 
@@ -304,8 +300,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
         if (s_fragmentOptions.MaxChunkSize <= 0)
         {
             throw new InvalidOperationException(
-                $"[{nameof(SocketConnection)}] Invalid configuration: " +
-                $"MaxChunkSize must be > 0, got {s_fragmentOptions.MaxChunkSize}.");
+                $"[{nameof(SocketConnection)}] Invalid configuration: MaxChunkSize must be > 0, got {s_fragmentOptions.MaxChunkSize}.");
         }
 
         // 5 bytes is the max size of a VarInt header. We use this to ensure the buffer is
@@ -355,7 +350,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
                         if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                         {
-                            _logger.LogDebug($"[NW.{nameof(SocketConnection)}] invalid-size={size} ep={_endpointString}");
+                            _logger.LogDebug("[NW.SocketConnection] invalid-size={Size} ep={Endpoint}", size, _endpointString);
                         }
 #endif
                         Throw.ProtocolNotSupportedNow();
@@ -463,18 +458,14 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.LogTrace(
-                    $"[NW.{nameof(SocketConnection)}:{nameof(SAEA_RECEIVE_LOOP_ASYNC)}] " +
-                    $"ended (peer closed/shutdown) ep={_owner?.NetworkEndpoint.Address}");
+                _logger.LogTrace("[NW.SocketConnection:SAEA_RECEIVE_LOOP_ASYNC] ended (peer closed/shutdown) ep={OwnerNetworkEndpointAddress}", _owner?.NetworkEndpoint.Address);
             }
         }
         catch (OperationCanceledException)
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.LogTrace(
-                    $"[NW.{nameof(SocketConnection)}:{nameof(SAEA_RECEIVE_LOOP_ASYNC)}] " +
-                    $"cancelled ep={_owner?.NetworkEndpoint.Address}");
+                _logger.LogTrace("[NW.SocketConnection:SAEA_RECEIVE_LOOP_ASYNC] cancelled ep={OwnerNetworkEndpointAddress}", _owner?.NetworkEndpoint.Address);
             }
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
@@ -589,8 +580,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning($"[NW.{nameof(SocketConnection)}] malformed-payload " +
-                                 $"length={payloadLen} (too small for protocol header) ep={_endpointString}");
+                _logger.LogWarning("[NW.SocketConnection] malformed-payload length={PayloadLength} (too small for protocol header) ep={Endpoint}", payloadLen, _endpointString);
             }
 #endif
             lease.Dispose();
@@ -609,8 +599,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning($"[NW.{nameof(SocketConnection)}] frame-dropped " +
-                                  $"length={payloadLen} ep={_endpointString}");
+                _logger.LogWarning("[NW.SocketConnection] frame-dropped length={PayloadLength} ep={Endpoint}", payloadLen, _endpointString);
             }
 #endif
             lease.Dispose();
@@ -619,9 +608,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
         if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug(
-                $"[NW.{nameof(SocketConnection)}] handoff-to-sink " +
-                $"payload={payloadLen} ep={_endpointString}");
+            _logger.LogDebug("[NW.SocketConnection] handoff-to-sink payload={PayloadLength} ep={Endpoint}", payloadLen, _endpointString);
         }
 #endif
     }
@@ -647,7 +634,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
                     if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                     {
-                        _logger.LogDebug($"[NW.{nameof(SocketConnection)}] fragment-limit open={openStreams} ep={_endpointString}");
+                        _logger.LogDebug("[NW.SocketConnection] fragment-limit open={OpenStreams} ep={Endpoint}", openStreams, _endpointString);
                     }
 #endif
                     return;
@@ -657,9 +644,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug(
-                    $"[NW.{nameof(SocketConnection)}] recv-frag stream={header.StreamId} chunk={header.ChunkIndex}/{header.TotalChunks} " +
-                    $"last={header.IsLast} ep={_endpointString}");
+                _logger.LogDebug("[NW.SocketConnection] recv-frag stream={StreamId} chunk={HeaderChunkIndex}/{HeaderTotalChunks} last={HeaderIsLast} ep={Endpoint}", header.StreamId, header.ChunkIndex, header.TotalChunks, header.IsLast, _endpointString);
             }
 #endif
 
@@ -683,7 +668,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
                     if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                     {
-                        _logger.LogDebug($"[NW.{nameof(SocketConnection)}] assembled stream={header.StreamId} ep={_endpointString}");
+                        _logger.LogDebug("[NW.SocketConnection] assembled stream={StreamId} ep={Endpoint}", header.StreamId, _endpointString);
                     }
 #endif
                     Interlocked.Decrement(ref _openFragmentStreams);
@@ -737,9 +722,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
                     if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
                     {
-                        _logger.LogTrace(
-                            $"[NW.{nameof(SocketConnection)}:{nameof(DISPOSE)}] " +
-                            $"socket-shutdown-ignored disposed ep={_endpointString} ex={ex.Message}");
+                        _logger.LogTrace(ex, "[NW.SocketConnection:DISPOSE] socket-shutdown-ignored disposed ep={Endpoint} ex=", _endpointString);
                     }
 #endif
                 }
@@ -748,9 +731,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
                     if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
                     {
-                        _logger.LogTrace(
-                            $"[NW.{nameof(SocketConnection)}:{nameof(DISPOSE)}] " +
-                            $"socket-shutdown-benign ep={_endpointString} code={ex.SocketErrorCode}");
+                        _logger.LogTrace(ex, "[NW.SocketConnection:DISPOSE] socket-shutdown-benign ep={Endpoint} code={SocketError}", _endpointString, ex.SocketErrorCode);
                     }
 #endif
                 }
@@ -758,7 +739,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
                 {
                     if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
                     {
-                        _logger.LogWarning(ex, $"[NW.{nameof(SocketConnection)}:{nameof(DISPOSE)}] socket-shutdown-failed ep={_endpointString}");
+                        _logger.LogWarning(ex, "[NW.SocketConnection:DISPOSE] socket-shutdown-failed ep={Endpoint}", _endpointString);
                     }
                 }
 
@@ -772,9 +753,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
                     if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
                     {
-                        _logger.LogTrace(
-                            $"[NW.{nameof(SocketConnection)}:{nameof(DISPOSE)}] " +
-                            $"socket-close-ignored disposed ep={_endpointString} ex={ex.Message}");
+                        _logger.LogTrace(ex, "[NW.SocketConnection:DISPOSE] socket-close-ignored disposed ep={Endpoint} ex=", _endpointString);
                     }
 #endif
                 }
@@ -782,7 +761,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
                 {
                     if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
                     {
-                        _logger.LogWarning(ex, $"[NW.{nameof(SocketConnection)}:{nameof(DISPOSE)}] socket-close-failed ep={_endpointString}");
+                        _logger.LogWarning(ex, "[NW.SocketConnection:DISPOSE] socket-close-failed ep={Endpoint}", _endpointString);
                     }
                 }
             }
@@ -832,9 +811,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
 #if DEBUG
         if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
         {
-            _logger.LogTrace(
-                $"[NW.{nameof(SocketConnection)}:{nameof(Dispose)}] " +
-                $"disposed ep={_endpointString}");
+            _logger.LogTrace("[NW.SocketConnection:Dispose] disposed ep={Endpoint}", _endpointString);
         }
 #endif
     }
@@ -853,7 +830,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
             {
                 if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
                 {
-                    _logger.LogWarning(ex, $"[NW.{nameof(SocketConnection)}:{nameof(DISPOSE)}] receive-loop-faulted-during-dispose ep={_endpointString}");
+                    _logger.LogWarning(ex, "[NW.SocketConnection:DISPOSE] receive-loop-faulted-during-dispose ep={Endpoint}", _endpointString);
                 }
             }
             return;
@@ -871,9 +848,7 @@ internal sealed partial class SocketConnection(Socket socket, IConnection owner,
             {
                 if (self._logger != null && self._logger.IsEnabled(LogLevel.Warning))
                 {
-                    self._logger.LogWarning(ex,
-                        $"[NW.{nameof(SocketConnection)}:{nameof(DISPOSE)}] " +
-                        $"receive-loop-faulted-after-dispose ep={self._endpointString}");
+                    self._logger.LogWarning(ex, "[NW.SocketConnection:DISPOSE] receive-loop-faulted-after-dispose ep={SelfEndpointString}", self._endpointString);
                 }
             }
         }, this, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);

--- a/src/Nalix.Network/Internal/Transport/SocketUdpTransport.cs
+++ b/src/Nalix.Network/Internal/Transport/SocketUdpTransport.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -166,7 +166,7 @@ internal sealed class SocketUdpTransport : IConnection.ITransport, IPoolable, ID
                 {
                     if (s_logger != null && s_logger.IsEnabled(LogLevel.Debug))
                     {
-                        s_logger.LogDebug($"[NW.{nameof(SocketUdpTransport)}:{nameof(Initialize)}] dualmode-not-applied reason={ex.GetType().Name}");
+                        s_logger.LogDebug(ex, "[NW.SocketUdpTransport:Initialize] dualmode-not-applied reason={ExceptionType}", ex.GetType().Name);
                     }
                 }
             }
@@ -182,28 +182,28 @@ internal sealed class SocketUdpTransport : IConnection.ITransport, IPoolable, ID
             {
                 if (s_logger != null && s_logger.IsEnabled(LogLevel.Debug))
                 {
-                    s_logger.LogDebug($"[NW.{nameof(SocketUdpTransport)}:{nameof(Initialize)}] dontfragment-not-applied reason={ex.SocketErrorCode}");
+                    s_logger.LogDebug(ex, "[NW.SocketUdpTransport:Initialize] dontfragment-not-applied reason={SocketError}", ex.SocketErrorCode);
                 }
             }
             catch (NotSupportedException ex)
             {
                 if (s_logger != null && s_logger.IsEnabled(LogLevel.Debug))
                 {
-                    s_logger.LogDebug($"[NW.{nameof(SocketUdpTransport)}:{nameof(Initialize)}] dontfragment-not-supported reason={ex.GetType().Name}");
+                    s_logger.LogDebug(ex, "[NW.SocketUdpTransport:Initialize] dontfragment-not-supported reason={ExceptionType}", ex.GetType().Name);
                 }
             }
             catch (ObjectDisposedException ex)
             {
                 if (s_logger != null && s_logger.IsEnabled(LogLevel.Debug))
                 {
-                    s_logger.LogDebug($"[NW.{nameof(SocketUdpTransport)}:{nameof(Initialize)}] dontfragment-object-disposed reason={ex.GetType().Name}");
+                    s_logger.LogDebug(ex, "[NW.SocketUdpTransport:Initialize] dontfragment-object-disposed reason={ExceptionType}", ex.GetType().Name);
                 }
             }
             catch (InvalidOperationException ex)
             {
                 if (s_logger != null && s_logger.IsEnabled(LogLevel.Debug))
                 {
-                    s_logger.LogDebug($"[NW.{nameof(SocketUdpTransport)}:{nameof(Initialize)}] dontfragment-invalid-op reason={ex.GetType().Name}");
+                    s_logger.LogDebug(ex, "[NW.SocketUdpTransport:Initialize] dontfragment-invalid-op reason={ExceptionType}", ex.GetType().Name);
                 }
             }
 
@@ -218,7 +218,7 @@ internal sealed class SocketUdpTransport : IConnection.ITransport, IPoolable, ID
                 {
                     if (s_logger != null && s_logger.IsEnabled(LogLevel.Debug))
                     {
-                        s_logger.LogDebug($"[NW.{nameof(SocketUdpTransport)}:{nameof(Initialize)}] udp-connreset-ioctl-not-applied reason={ex.GetType().Name}");
+                        s_logger.LogDebug(ex, "[NW.SocketUdpTransport:Initialize] udp-connreset-ioctl-not-applied reason={ExceptionType}", ex.GetType().Name);
                     }
                 }
             }

--- a/src/Nalix.Network/Internal/Transport/WebSocketTransport.cs
+++ b/src/Nalix.Network/Internal/Transport/WebSocketTransport.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -189,7 +189,7 @@ internal sealed class WebSocketTransport : IConnection.ITransport, IDisposable
         {
             if (_owner.Logger != null && _owner.Logger.IsEnabled(LogLevel.Error))
             {
-                _owner.Logger.LogError(ex, $"[NW.{nameof(WebSocketConnection)}] Receive loop error");
+                _owner.Logger.LogError(ex, "[NW.WebSocketConnection] Receive loop error");
             }
         }
         finally
@@ -291,7 +291,7 @@ internal sealed class WebSocketTransport : IConnection.ITransport, IDisposable
     {
         if (owner.Logger != null && owner.Logger.IsEnabled(LogLevel.Debug))
         {
-            owner.Logger.LogDebug(ex, $"[NW.{nameof(WebSocketTransport)}:{nameof(Dispose)}] receive-loop-faulted-{phase}");
+            owner.Logger.LogDebug(ex, "[NW.WebSocketTransport:Dispose] receive-loop-faulted-{Phase}", phase);
         }
     }
 

--- a/src/Nalix.Network/Listeners/TcpListener/TcpListener.Core.cs
+++ b/src/Nalix.Network/Listeners/TcpListener/TcpListener.Core.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -187,18 +187,14 @@ public abstract partial class TcpListenerBase : IListener
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                     {
-                        this.Logger.LogDebug(
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(SCHEDULE_STOP)}] " +
-                            $"cts-cancel-ignored port={self._port} reason={ex.GetType().Name}");
+                        this.Logger.LogDebug(ex, "[NW.TcpListenerBase:SCHEDULE_STOP] cts-cancel-ignored port={Port} reason={ExceptionType}", self._port, ex.GetType().Name);
                     }
                 }
                 catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                     {
-                        this.Logger.LogWarning(ex,
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(SCHEDULE_STOP)}] " +
-                            $"cts-cancel-failed port={self._port}");
+                        this.Logger.LogWarning(ex, "[NW.TcpListenerBase:SCHEDULE_STOP] cts-cancel-failed port={Port}", self._port);
                     }
                 }
 
@@ -211,18 +207,14 @@ public abstract partial class TcpListenerBase : IListener
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                     {
-                        this.Logger.LogDebug(
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(SCHEDULE_STOP)}] " +
-                            $"listener-close-ignored port={self._port} reason={ex.GetType().Name}");
+                        this.Logger.LogDebug(ex, "[NW.TcpListenerBase:SCHEDULE_STOP] listener-close-ignored port={Port} reason={ExceptionType}", self._port, ex.GetType().Name);
                     }
                 }
                 catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                     {
-                        this.Logger.LogWarning(ex,
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(SCHEDULE_STOP)}] " +
-                            $"listener-close-failed port={self._port}");
+                        this.Logger.LogWarning(ex, "[NW.TcpListenerBase:SCHEDULE_STOP] listener-close-failed port={Port}", self._port);
                     }
                 }
                 self._listener = null;
@@ -242,9 +234,7 @@ public abstract partial class TcpListenerBase : IListener
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                     {
-                        this.Logger.LogWarning(ex,
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(SCHEDULE_STOP)}] " +
-                            $"cancel-group-failed port={self._port}");
+                        this.Logger.LogWarning(ex, "[NW.TcpListenerBase:SCHEDULE_STOP] cancel-group-failed port={Port}", self._port);
                     }
                 }
 
@@ -252,18 +242,14 @@ public abstract partial class TcpListenerBase : IListener
 
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Information))
                 {
-                    this.Logger.LogInformation(
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(SCHEDULE_STOP)}] " +
-                        $"stopped port={self._port}");
+                    this.Logger.LogInformation("[NW.TcpListenerBase:SCHEDULE_STOP] stopped port={Port}", self._port);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
                 {
-                    this.Logger.LogError(ex,
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(SCHEDULE_STOP)}] " +
-                        $"stop-error port={self._port}");
+                    this.Logger.LogError(ex, "[NW.TcpListenerBase:SCHEDULE_STOP] stop-error port={Port}", self._port);
                 }
             }
             finally
@@ -276,18 +262,14 @@ public abstract partial class TcpListenerBase : IListener
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                     {
-                        this.Logger.LogDebug(
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(SCHEDULE_STOP)}] " +
-                            $"cts-dispose-ignored port={self._port} reason={ex.GetType().Name}");
+                        this.Logger.LogDebug(ex, "[NW.TcpListenerBase:SCHEDULE_STOP] cts-dispose-ignored port={Port} reason={ExceptionType}", self._port, ex.GetType().Name);
                     }
                 }
                 catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                     {
-                        this.Logger.LogWarning(ex,
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(SCHEDULE_STOP)}] " +
-                            $"cts-dispose-failed port={self._port}");
+                        this.Logger.LogWarning(ex, "[NW.TcpListenerBase:SCHEDULE_STOP] cts-dispose-failed port={Port}", self._port);
                     }
                 }
                 self._cts = null;
@@ -304,27 +286,21 @@ public abstract partial class TcpListenerBase : IListener
                     {
                         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                         {
-                            this.Logger.LogWarning(ex,
-                                $"[NW.{nameof(TcpListenerBase)}:{nameof(SCHEDULE_STOP)}] " +
-                                $"lock-release-ignored port={self._port} reason={nameof(SemaphoreFullException)}");
+                            this.Logger.LogWarning(ex, "[NW.TcpListenerBase:SCHEDULE_STOP] lock-release-ignored port={Port} reason=SemaphoreFullException", self._port);
                         }
                     }
                     catch (ObjectDisposedException ex)
                     {
                         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                         {
-                            this.Logger.LogWarning(ex,
-                                $"[NW.{nameof(TcpListenerBase)}:{nameof(SCHEDULE_STOP)}] " +
-                                $"lock-release-ignored port={self._port} reason={nameof(ObjectDisposedException)}");
+                            this.Logger.LogWarning(ex, "[NW.TcpListenerBase:SCHEDULE_STOP] lock-release-ignored port={Port} reason=ObjectDisposedException", self._port);
                         }
                     }
                     catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
                     {
                         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
                         {
-                            this.Logger.LogError(ex,
-                                $"[NW.{nameof(TcpListenerBase)}:{nameof(SCHEDULE_STOP)}] " +
-                                $"lock-release-error port={self._port}");
+                            this.Logger.LogError(ex, "[NW.TcpListenerBase:SCHEDULE_STOP] lock-release-error port={Port}", self._port);
                         }
                     }
                 }
@@ -379,18 +355,14 @@ public abstract partial class TcpListenerBase : IListener
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                     {
-                        this.Logger.LogDebug(
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(Dispose)}] " +
-                            $"cancel-reg-dispose-ignored port={_port} reason={ex.GetType().Name}");
+                        this.Logger.LogDebug(ex, "[NW.TcpListenerBase:Dispose] cancel-reg-dispose-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                     }
                 }
                 catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                     {
-                        this.Logger.LogWarning(ex,
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(Dispose)}] " +
-                            $"cancel-reg-dispose-failed port={_port}");
+                        this.Logger.LogWarning(ex, "[NW.TcpListenerBase:Dispose] cancel-reg-dispose-failed port={Port}", _port);
                     }
                 }
 
@@ -402,18 +374,14 @@ public abstract partial class TcpListenerBase : IListener
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                     {
-                        this.Logger.LogDebug(
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(Dispose)}] " +
-                            $"cts-cancel-ignored port={_port} reason={ex.GetType().Name}");
+                        this.Logger.LogDebug(ex, "[NW.TcpListenerBase:Dispose] cts-cancel-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                     }
                 }
                 catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                     {
-                        this.Logger.LogWarning(ex,
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(Dispose)}] " +
-                            $"cts-cancel-failed port={_port}");
+                        this.Logger.LogWarning(ex, "[NW.TcpListenerBase:Dispose] cts-cancel-failed port={Port}", _port);
                     }
                 }
 
@@ -425,18 +393,14 @@ public abstract partial class TcpListenerBase : IListener
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                     {
-                        this.Logger.LogDebug(
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(Dispose)}] " +
-                            $"cts-dispose-ignored port={_port} reason={ex.GetType().Name}");
+                        this.Logger.LogDebug(ex, "[NW.TcpListenerBase:Dispose] cts-dispose-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                     }
                 }
                 catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                     {
-                        this.Logger.LogWarning(ex,
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(Dispose)}] " +
-                            $"cts-dispose-failed port={_port}");
+                        this.Logger.LogWarning(ex, "[NW.TcpListenerBase:Dispose] cts-dispose-failed port={Port}", _port);
                     }
                 }
 
@@ -451,18 +415,14 @@ public abstract partial class TcpListenerBase : IListener
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                     {
-                        this.Logger.LogDebug(
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(Dispose)}] " +
-                            $"listener-dispose-ignored port={_port} reason={ex.GetType().Name}");
+                        this.Logger.LogDebug(ex, "[NW.TcpListenerBase:Dispose] listener-dispose-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                     }
                 }
                 catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                     {
-                        this.Logger.LogWarning(ex,
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(Dispose)}] " +
-                            $"listener-dispose-failed port={_port}");
+                        this.Logger.LogWarning(ex, "[NW.TcpListenerBase:Dispose] listener-dispose-failed port={Port}", _port);
                     }
                 }
                 finally
@@ -474,9 +434,7 @@ public abstract partial class TcpListenerBase : IListener
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
                 {
-                    this.Logger.LogError(ex,
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(Dispose)}] " +
-                        $"dispose-failed port={_port}");
+                    this.Logger.LogError(ex, "[NW.TcpListenerBase:Dispose] dispose-failed port={Port}", _port);
                 }
             }
 
@@ -501,7 +459,7 @@ public abstract partial class TcpListenerBase : IListener
 
         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
         {
-            this.Logger.LogDebug($"[NW.{nameof(TcpListenerBase)}:{nameof(Dispose)}] disposed");
+            this.Logger.LogDebug("[NW.TcpListenerBase:Dispose] disposed");
         }
     }
 

--- a/src/Nalix.Network/Listeners/TcpListener/TcpListener.Handle.cs
+++ b/src/Nalix.Network/Listeners/TcpListener/TcpListener.Handle.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -55,19 +55,14 @@ public abstract partial class TcpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace(
-                    $"[NW.{nameof(TcpListenerBase)}:{nameof(ProcessConnection)}] " +
-                    $"new={connection.NetworkEndpoint}");
+                this.Logger.LogTrace("[NW.TcpListenerBase:ProcessConnection] new={ConnectionNetworkEndpoint}", connection.NetworkEndpoint);
             }
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
             {
-                this.Logger.LogError(
-                    ex,
-                    $"[NW.{nameof(TcpListenerBase)}:{nameof(ProcessConnection)}] " +
-                    $"process-error={connection.NetworkEndpoint}");
+                this.Logger.LogError(ex, "[NW.TcpListenerBase:ProcessConnection] process-error={ConnectionNetworkEndpoint}", connection.NetworkEndpoint);
             }
 
             // Disconnect the connection immediately if an error occurs -> prevent resource leaks.
@@ -116,9 +111,7 @@ public abstract partial class TcpListenerBase
 
         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
         {
-            this.Logger.LogTrace(
-                $"[NW.{nameof(TcpListenerBase)}:{nameof(HandleConnectionClose)}] " +
-                $"close={args.Connection.NetworkEndpoint}");
+            this.Logger.LogTrace("[NW.TcpListenerBase:HandleConnectionClose] close={ArgsConnectionNetworkEndpoint}", args.Connection.NetworkEndpoint);
         }
 
         args.Connection.Dispose();
@@ -270,7 +263,7 @@ public abstract partial class TcpListenerBase
             {
                 // Log in Trace (not Error) because this is expected failure in error-recovery path.
                 // WHY not rethrow: Currently in cleanup path -> the second exception will obscure the original exception.
-                this.Logger.LogTrace($"[NW.{nameof(TcpListenerBase)}:Internal] accept-error ex={ex.Message}");
+                this.Logger.LogTrace(ex, "[NW.TcpListenerBase:Internal] accept-error ex=");
             }
         }
     }
@@ -328,7 +321,7 @@ public abstract partial class TcpListenerBase
                 // This is an early exit for all OS-level errors (Interrupted, OperationAborted, etc.)
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning($"[NW.{nameof(TcpListenerBase)}:{nameof(HandleAccept)}] accept-failed={args.SocketError}");
+                    this.Logger.LogWarning("[NW.TcpListenerBase:HandleAccept] accept-failed={SocketError}", args.SocketError);
                 }
 
                 this.RebindAcceptContext((PooledSocketAsyncEventArgs)args);
@@ -342,7 +335,7 @@ public abstract partial class TcpListenerBase
                 // No socket to log endpoint, logging warning is sufficient.
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning($"[NW.{nameof(TcpListenerBase)}:{nameof(HandleAccept)}] accept-socket-null port={_port}");
+                    this.Logger.LogWarning("[NW.TcpListenerBase:HandleAccept] accept-socket-null port={Port}", _port);
                 }
 
                 this.RebindAcceptContext((PooledSocketAsyncEventArgs)args);
@@ -364,7 +357,7 @@ public abstract partial class TcpListenerBase
                     this.Metrics.RECORD_REJECTED();
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                     {
-                        this.Logger.LogWarning($"[NW.{nameof(TcpListenerBase)}:{nameof(HandleAccept)}] channel-full port={_port} - dropped socket directly");
+                        this.Logger.LogWarning("[NW.TcpListenerBase:HandleAccept] channel-full port={Port} - dropped socket directly", _port);
                     }
                     this.SafeCloseSocket(socket);
                     this.RebindAcceptContext((PooledSocketAsyncEventArgs)args);
@@ -377,7 +370,7 @@ public abstract partial class TcpListenerBase
                     {
                         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                         {
-                            this.Logger.LogWarning($"[NW.{nameof(TcpListenerBase)}:{nameof(HandleAccept)}] untrusted-proxy-rejected remote={remoteEp}");
+                            this.Logger.LogWarning("[NW.TcpListenerBase:HandleAccept] untrusted-proxy-rejected remote={RemoteEndpoint}", remoteEp);
                         }
 
                         this.Metrics.RECORD_REJECTED();
@@ -413,7 +406,7 @@ public abstract partial class TcpListenerBase
                 // Listener is disposed of while accept is running -> this is expected shutdown case.
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning($"[NW.{nameof(TcpListenerBase)}:{nameof(HandleAccept)}] disposed-during-accept remote={socket.RemoteEndPoint?.ToString() ?? "<null>"}");
+                    this.Logger.LogWarning("[NW.TcpListenerBase:HandleAccept] disposed-during-accept remote={RemoteEndpoint}", socket.RemoteEndPoint?.ToString() ?? "<null>");
                 }
 
                 if (connection != null)
@@ -432,7 +425,7 @@ public abstract partial class TcpListenerBase
                 this.Metrics.RECORD_ERROR();
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
                 {
-                    this.Logger.LogError(ex, $"[NW.{nameof(TcpListenerBase)}:{nameof(HandleAccept)}] accept-error port={_port}");
+                    this.Logger.LogError(ex, "[NW.TcpListenerBase:HandleAccept] accept-error port={Port}", _port);
                 }
 
                 if (connection != null)
@@ -608,7 +601,7 @@ public abstract partial class TcpListenerBase
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
                 {
-                    this.Logger.LogError(ex, $"[NW.{nameof(TcpListenerBase)}:{nameof(AcceptNext)}] accept-error port={_port}");
+                    this.Logger.LogError(ex, "[NW.TcpListenerBase:AcceptNext] accept-error port={Port}", _port);
                 }
 
                 // Delay 50ms to avoid CPU spinning during persistent errors (eg, file descriptor explosion).
@@ -692,9 +685,7 @@ public abstract partial class TcpListenerBase
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
                 {
                     // Token cancelled -> shutdown graceful -> exit loop.
-                    this.Logger.LogTrace(
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(AcceptConnectionsAsync)}] " +
-                        $"shutdown-requested port={_port}");
+                    this.Logger.LogTrace("[NW.TcpListenerBase:AcceptConnectionsAsync] shutdown-requested port={Port}", _port);
                 }
 
                 break;
@@ -722,7 +713,7 @@ public abstract partial class TcpListenerBase
                 this.Metrics.RECORD_ERROR();
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning($"[NW.{nameof(TcpListenerBase)}:{nameof(AcceptConnectionsAsync)}] transient-socket-error={ex.SocketErrorCode} port={_port}");
+                    this.Logger.LogWarning(ex, "[NW.TcpListenerBase:AcceptConnectionsAsync] transient-socket-error={SocketError} port={Port}", ex.SocketErrorCode, _port);
                 }
 
                 // Transient OS-level error -> record metric + delay + retry.
@@ -736,10 +727,7 @@ public abstract partial class TcpListenerBase
                 this.Metrics.RECORD_ERROR();
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
                 {
-                    this.Logger.LogError(
-                        ex,
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(AcceptConnectionsAsync)}] " +
-                        $"accept-error port={_port}");
+                    this.Logger.LogError(ex, "[NW.TcpListenerBase:AcceptConnectionsAsync] accept-error port={Port}", _port);
                 }
 
                 // Unexpected error -> record + log + delay 50ms to avoid CPU spin.
@@ -751,9 +739,7 @@ public abstract partial class TcpListenerBase
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
                 {
-                    this.Logger.LogTrace(
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(AcceptConnectionsAsync)}] " +
-                        $"accepted remote={connection.NetworkEndpoint} port={_port}");
+                    this.Logger.LogTrace("[NW.TcpListenerBase:AcceptConnectionsAsync] accepted remote={ConnectionNetworkEndpoint} port={Port}", connection.NetworkEndpoint, _port);
                 }
 
                 // Send the connection to process channel -> consumer thread for processing.
@@ -764,9 +750,7 @@ public abstract partial class TcpListenerBase
 
         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
         {
-            this.Logger.LogTrace(
-                $"[NW.{nameof(TcpListenerBase)}:{nameof(AcceptConnectionsAsync)}] " +
-                $"loop-exited port={_port}");
+            this.Logger.LogTrace("[NW.TcpListenerBase:AcceptConnectionsAsync] loop-exited port={Port}", _port);
         }
     }
 
@@ -907,18 +891,14 @@ public abstract partial class TcpListenerBase
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug(
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(CreateConnectionAsync)}] " +
-                        $"listener-endpoint-disposed port={_port} reason={ode.GetType().Name}");
+                    this.Logger.LogDebug(ex, "[NW.TcpListenerBase:CreateConnectionAsync] listener-endpoint-disposed port={Port} reason={Type}", _port, ode.GetType().Name);
                 }
             }
             catch (Exception lookupEx) when (ExceptionClassifier.IsNonFatal(lookupEx))
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(lookupEx,
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(CreateConnectionAsync)}] " +
-                        $"listener-endpoint-lookup-failed port={_port}");
+                    this.Logger.LogWarning(lookupEx, "[NW.TcpListenerBase:CreateConnectionAsync] listener-endpoint-lookup-failed port={Port}", _port);
                 }
             }
             throw new NetworkException($"TryAccept failed. Listener={remote}", ex);

--- a/src/Nalix.Network/Listeners/TcpListener/TcpListener.ProcessChannel.cs
+++ b/src/Nalix.Network/Listeners/TcpListener/TcpListener.ProcessChannel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -132,8 +132,7 @@ public abstract partial class TcpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
             {
-                this.Logger.LogWarning($"[NW.{nameof(TcpListenerBase)}:{nameof(DISPATCH_CONNECTION)}] " +
-                                 $"process-channel-unavailable remote={connection?.NetworkEndpoint.ToString() ?? "<null>"} port={_port}");
+                this.Logger.LogWarning("[NW.TcpListenerBase:DISPATCH_CONNECTION] process-channel-unavailable remote={RemoteEndpoint}", connection?.NetworkEndpoint.ToString() ?? "<null>");
             }
 
             ArgumentNullException.ThrowIfNull(connection);
@@ -145,9 +144,7 @@ public abstract partial class TcpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace(
-                    $"[NW.{nameof(TcpListenerBase)}:{nameof(DISPATCH_CONNECTION)}] " +
-                    $"queued remote={connection?.NetworkEndpoint.ToString() ?? "<null>"} port={_port}");
+                this.Logger.LogTrace("[NW.TcpListenerBase:DISPATCH_CONNECTION] queued remote={RemoteEndpoint}", connection?.NetworkEndpoint.ToString() ?? "<null>");
             }
 
             return;
@@ -163,8 +160,7 @@ public abstract partial class TcpListenerBase
 
         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
         {
-            this.Logger.LogWarning($"[NW.{nameof(TcpListenerBase)}:{nameof(DISPATCH_CONNECTION)}] " +
-                             $"channel-full remote={connection?.NetworkEndpoint.ToString() ?? "<null>"} port={_port} - dropped");
+            this.Logger.LogWarning("[NW.TcpListenerBase:DISPATCH_CONNECTION] channel-full remote={RemoteEndpoint}", connection?.NetworkEndpoint.ToString() ?? "<null>");
         }
 
         ArgumentNullException.ThrowIfNull(connection);
@@ -179,9 +175,7 @@ public abstract partial class TcpListenerBase
     {
         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
         {
-            this.Logger.LogTrace(
-                $"[NW.{nameof(TcpListenerBase)}:{nameof(PROCESS_CHANNEL_LOOP_ASYNC)}] " +
-                $"worker-started port={_port}");
+            this.Logger.LogTrace("[NW.TcpListenerBase:PROCESS_CHANNEL_LOOP_ASYNC] worker-started port={Port}", _port);
         }
 
         System.Threading.Channels.Channel<IConnection>? processChannel = _processChannel;
@@ -226,7 +220,7 @@ public abstract partial class TcpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
             {
-                this.Logger.LogError(ex, $"[NW.{nameof(TcpListenerBase)}:{nameof(PROCESS_CHANNEL_LOOP_ASYNC)}] unhandled-error port={_port}");
+                this.Logger.LogError(ex, "[NW.TcpListenerBase:PROCESS_CHANNEL_LOOP_ASYNC] unhandled-error port={Port}", _port);
             }
         }
         finally
@@ -244,7 +238,7 @@ public abstract partial class TcpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace($"[NW.{nameof(TcpListenerBase)}:{nameof(PROCESS_CHANNEL_LOOP_ASYNC)}] worker-exited port={_port}");
+                this.Logger.LogTrace("[NW.TcpListenerBase:PROCESS_CHANNEL_LOOP_ASYNC] worker-exited port={Port}", _port);
             }
         }
     }
@@ -272,10 +266,7 @@ public abstract partial class TcpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
             {
-                this.Logger.LogError(
-                    ex,
-                    $"[NW.{nameof(TcpListenerBase)}:{nameof(INVOKE_PROCESS)}] " +
-                    $"error remote={connection?.NetworkEndpoint.ToString() ?? "<null>"} port={_port}");
+                this.Logger.LogError(ex, "[NW.TcpListenerBase:INVOKE_PROCESS] error remote={RemoteEndpoint}", connection?.NetworkEndpoint.ToString() ?? "<null>");
             }
 
             ArgumentNullException.ThrowIfNull(connection);

--- a/src/Nalix.Network/Listeners/TcpListener/TcpListener.ProxyProtocol.cs
+++ b/src/Nalix.Network/Listeners/TcpListener/TcpListener.ProxyProtocol.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -200,9 +200,7 @@ public abstract partial class TcpListenerBase
 
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
                 {
-                    this.Logger.LogTrace(
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(OnProxyReadCompleted)}] " +
-                        $"invalid-proxy-header-drop remote={state.Socket?.RemoteEndPoint}");
+                    this.Logger.LogTrace("[NW.TcpListenerBase:OnProxyReadCompleted] invalid-proxy-header-drop remote={StateSocketRemoteEndPoint}", state.Socket?.RemoteEndPoint);
                 }
 
                 this.ReleaseProxyContext(state, args, success: false);
@@ -241,9 +239,7 @@ public abstract partial class TcpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace(
-                    $"[NW.{nameof(TcpListenerBase)}:{nameof(OnProxyReadCompleted)}] " +
-                    $"proxy-rate-limit-drop remote={effectiveIp}");
+                this.Logger.LogTrace("[NW.TcpListenerBase:OnProxyReadCompleted] proxy-rate-limit-drop remote={EffectiveIp}", effectiveIp);
             }
 
             this.ReleaseProxyContext(state, args, success: false);
@@ -262,7 +258,7 @@ public abstract partial class TcpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace($"[NW.{nameof(TcpListenerBase)}:{nameof(OnProxyReadCompleted)}] socket-disposed-during-init");
+                this.Logger.LogTrace("[NW.TcpListenerBase:OnProxyReadCompleted] socket-disposed-during-init");
             }
         }
         catch (SocketException ex) when (
@@ -273,14 +269,14 @@ public abstract partial class TcpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace($"[NW.{nameof(TcpListenerBase)}:{nameof(OnProxyReadCompleted)}] socket-error-during-init: {ex.SocketErrorCode}");
+                this.Logger.LogTrace(ex, "[NW.TcpListenerBase:OnProxyReadCompleted] socket-error-during-init: {SocketError}", ex.SocketErrorCode);
             }
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
             {
-                this.Logger.LogError(ex, $"[NW.{nameof(TcpListenerBase)}:{nameof(OnProxyReadCompleted)}] init-error");
+                this.Logger.LogError(ex, "[NW.TcpListenerBase:OnProxyReadCompleted] init-error");
             }
         }
 

--- a/src/Nalix.Network/Listeners/TcpListener/TcpListener.PublicMethods.cs
+++ b/src/Nalix.Network/Listeners/TcpListener/TcpListener.PublicMethods.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -50,7 +50,7 @@ public abstract partial class TcpListenerBase
 
         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
         {
-            this.Logger.LogDebug($"[NW.{nameof(TcpListenerBase)}:{nameof(Activate)}] activate-request port={_port}");
+            this.Logger.LogDebug("[NW.TcpListenerBase:Activate] activate-request port={Port}", _port);
         }
 
         // Avoid blocking lifecycle transitions behind a concurrent caller.
@@ -58,9 +58,7 @@ public abstract partial class TcpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
             {
-                this.Logger.LogWarning(
-                    $"[NW.{nameof(TcpListenerBase)}:{nameof(Activate)}] " +
-                    $"activate-skipped lock-busy port={_port}");
+                this.Logger.LogWarning("[NW.TcpListenerBase:Activate] activate-skipped lock-busy port={Port}", _port);
             }
             return;
         }
@@ -75,7 +73,7 @@ public abstract partial class TcpListenerBase
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning($"[NW.{nameof(TcpListenerBase)}:{nameof(Activate)}] ignored-activate state={this.State}");
+                    this.Logger.LogWarning("[NW.TcpListenerBase:Activate] ignored-activate state={State}", this.State);
                 }
 
                 return;
@@ -121,7 +119,7 @@ public abstract partial class TcpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Information))
             {
-                this.Logger.LogInformation($"[NW.{nameof(TcpListenerBase)}:{nameof(Activate)}] start protocol={this.Protocol} port={_port}");
+                this.Logger.LogInformation("[NW.TcpListenerBase:Activate] start protocol={Protocol} port={Port}", this.Protocol, _port);
             }
 
             if (_config.EnableTimeout)
@@ -157,7 +155,7 @@ public abstract partial class TcpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Information))
             {
-                this.Logger.LogInformation($"[NW.{nameof(TcpListenerBase)}:{nameof(Activate)}] cancel port={_port}");
+                this.Logger.LogInformation("[NW.TcpListenerBase:Activate] cancel port={Port}", _port);
             }
 
             _ = Interlocked.Exchange(ref _state, (int)ListenerState.STOPPED);
@@ -166,7 +164,7 @@ public abstract partial class TcpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
             {
-                this.Logger.LogError(ex, $"[NW.{nameof(TcpListenerBase)}: {nameof(Activate)} ] start-failed port= {_port}");
+                this.Logger.LogError(ex, "[NW.TcpListenerBase: Activate ] start-failed port= {Port}", _port);
             }
 
             _ = Interlocked.Exchange(ref _state, (int)ListenerState.STOPPED);
@@ -175,7 +173,7 @@ public abstract partial class TcpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Critical))
             {
-                this.Logger.LogCritical(ex, $"[NW.{nameof(TcpListenerBase)}:{nameof(Activate)}] critical-error port={_port}");
+                this.Logger.LogCritical(ex, "[NW.TcpListenerBase:Activate] critical-error port={Port}", _port);
             }
 
             _ = Interlocked.Exchange(ref _state, (int)ListenerState.STOPPED);
@@ -204,7 +202,7 @@ public abstract partial class TcpListenerBase
 
         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
         {
-            this.Logger.LogDebug($"[NW.{nameof(TcpListenerBase)}:{nameof(Deactivate)}] deactivate-request port={_port}");
+            this.Logger.LogDebug("[NW.TcpListenerBase:Deactivate] deactivate-request port={Port}", _port);
         }
 
         // Try RUNNING -> STOPPING first; if that fails, allow STARTING -> STOPPING
@@ -221,7 +219,7 @@ public abstract partial class TcpListenerBase
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning($"[NW.{nameof(TcpListenerBase)}:{nameof(Deactivate)}] ignored-deactivate state={this.State}");
+                    this.Logger.LogWarning("[NW.TcpListenerBase:Deactivate] ignored-deactivate state={State}", this.State);
                 }
 
                 return;
@@ -239,18 +237,14 @@ public abstract partial class TcpListenerBase
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug(
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"cancel-reg-dispose-ignored port={_port} reason={ex.GetType().Name}");
+                    this.Logger.LogDebug(ex, "[NW.TcpListenerBase:Deactivate] cancel-reg-dispose-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(ex,
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"cancel-reg-dispose-failed port={_port}");
+                    this.Logger.LogWarning(ex, "[NW.TcpListenerBase:Deactivate] cancel-reg-dispose-failed port={Port}", _port);
                 }
             }
 
@@ -262,18 +256,14 @@ public abstract partial class TcpListenerBase
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug(
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"cts-cancel-ignored port={_port} reason={ex.GetType().Name}");
+                    this.Logger.LogDebug(ex, "[NW.TcpListenerBase:Deactivate] cts-cancel-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(ex,
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"cts-cancel-failed port={_port}");
+                    this.Logger.LogWarning(ex, "[NW.TcpListenerBase:Deactivate] cts-cancel-failed port={Port}", _port);
                 }
             }
 
@@ -285,18 +275,14 @@ public abstract partial class TcpListenerBase
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug(
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"listener-close-ignored port={_port} reason={ex.GetType().Name}");
+                    this.Logger.LogDebug(ex, "[NW.TcpListenerBase:Deactivate] listener-close-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(ex,
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"listener-close-failed port={_port}");
+                    this.Logger.LogWarning(ex, "[NW.TcpListenerBase:Deactivate] listener-close-failed port={Port}", _port);
                 }
             }
 
@@ -321,7 +307,7 @@ public abstract partial class TcpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Information))
             {
-                this.Logger.LogInformation($"[NW.{nameof(TcpListenerBase)}:{nameof(Deactivate)}] stop protocol={this.Protocol} port={_port}");
+                this.Logger.LogInformation("[NW.TcpListenerBase:Deactivate] stop protocol={Protocol} port={Port}", this.Protocol, _port);
             }
         }
         finally
@@ -334,18 +320,14 @@ public abstract partial class TcpListenerBase
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug(
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"cts-dispose-ignored port={_port} reason={ex.GetType().Name}");
+                    this.Logger.LogDebug(ex, "[NW.TcpListenerBase:Deactivate] cts-dispose-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(ex,
-                        $"[NW.{nameof(TcpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"cts-dispose-failed port={_port}");
+                    this.Logger.LogWarning(ex, "[NW.TcpListenerBase:Deactivate] cts-dispose-failed port={Port}", _port);
                 }
             }
 

--- a/src/Nalix.Network/Listeners/TcpListener/TcpListener.SocketConfig.cs
+++ b/src/Nalix.Network/Listeners/TcpListener/TcpListener.SocketConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -65,7 +65,7 @@ public abstract partial class TcpListenerBase
 
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug($"[NW.{nameof(TcpListenerBase)}:{nameof(Initialize)}] config-bind {epV6Any}.v6)");
+                    this.Logger.LogDebug("[NW.TcpListenerBase:Initialize] config-bind {EpV6Any}.v6)", epV6Any);
                 }
 
                 sock.Bind(epV6Any);
@@ -74,7 +74,7 @@ public abstract partial class TcpListenerBase
                 _listener = sock;
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug($"[NW.{nameof(TcpListenerBase)}:{nameof(Initialize)}] config-listen {_listener.LocalEndPoint}.dual");
+                    this.Logger.LogDebug("[NW.TcpListenerBase:Initialize] config-listen {LocalEndpoint}.dual", _listener.LocalEndPoint);
                 }
 
                 return;
@@ -85,7 +85,7 @@ public abstract partial class TcpListenerBase
                 // WHY not rethrow: Failover automatically is better than crashing the server.
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning($"[NW.{nameof(TcpListenerBase)}:{nameof(Initialize)}] failed-bind ex={ex.Message}");
+                    this.Logger.LogWarning(ex, "[NW.TcpListenerBase:Initialize] failed-bind");
                 }
 
                 try
@@ -96,18 +96,14 @@ public abstract partial class TcpListenerBase
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                     {
-                        this.Logger.LogDebug(
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(Initialize)}] " +
-                            $"ipv6-fallback-close-ignored reason={closeEx.GetType().Name}");
+                        this.Logger.LogDebug(ex, "[NW.TcpListenerBase:Initialize] ipv6-fallback-close-ignored reason={Type}", closeEx.GetType().Name);
                     }
                 }
                 catch (Exception closeEx) when (ExceptionClassifier.IsNonFatal(closeEx))
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                     {
-                        this.Logger.LogWarning(
-                            closeEx,
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(Initialize)}] ipv6-fallback-close-failed");
+                        this.Logger.LogWarning(closeEx, "[NW.TcpListenerBase:Initialize] ipv6-fallback-close-failed");
                     }
                 }
 
@@ -119,9 +115,7 @@ public abstract partial class TcpListenerBase
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                     {
-                        this.Logger.LogWarning(
-                            disposeEx,
-                            $"[NW.{nameof(TcpListenerBase)}:{nameof(Initialize)}] ipv6-fallback-dispose-failed");
+                        this.Logger.LogWarning(disposeEx, "[NW.TcpListenerBase:Initialize] ipv6-fallback-dispose-failed");
                     }
                 }
 
@@ -146,7 +140,7 @@ public abstract partial class TcpListenerBase
 
         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
         {
-            this.Logger.LogDebug($"[NW.{nameof(TcpListenerBase)}:{nameof(Initialize)}] config-bind {epV4Any}.v4");
+            this.Logger.LogDebug("[NW.TcpListenerBase:Initialize] config-bind {EpV4Any}.v4", epV4Any);
         }
 
         _listener.Bind(epV4Any);
@@ -154,7 +148,7 @@ public abstract partial class TcpListenerBase
 
         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
         {
-            this.Logger.LogDebug($"[NW.{nameof(TcpListenerBase)}:{nameof(Initialize)}] config-listen {_listener.LocalEndPoint}");
+            this.Logger.LogDebug("[NW.TcpListenerBase:Initialize] config-listen {LocalEndpoint}", _listener.LocalEndPoint);
         }
     }
 
@@ -321,7 +315,7 @@ public abstract partial class TcpListenerBase
                 // Graceful fallback
                 if (this.Logger?.IsEnabled(LogLevel.Debug) == true)
                 {
-                    this.Logger.LogDebug($"[{nameof(TcpListenerBase)}:InitializeOptions] SO_REUSEPORT not-supported platform/kernel");
+                    this.Logger.LogDebug("[TcpListenerBase:InitializeOptions] SO_REUSEPORT not-supported platform/kernel");
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex)) { /* Ignore if not supported. */ }

--- a/src/Nalix.Network/Listeners/UdpListener/UdpListener.Core.cs
+++ b/src/Nalix.Network/Listeners/UdpListener/UdpListener.Core.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -147,7 +147,8 @@ public abstract partial class UdpListenerBase
 
         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
         {
-            this.Logger.LogDebug($"[NW.{nameof(UdpListenerBase)}] created port={_port} protocol={protocol.GetType().Name}");
+            string protocolType = protocol.GetType().Name;
+            this.Logger.LogDebug("[NW.UdpListenerBase] created port={Port} protocol={ProtocolType}", _port, protocolType);
         }
     }
 
@@ -205,18 +206,14 @@ public abstract partial class UdpListenerBase
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug(
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Dispose)}] " +
-                        $"cts-dispose-ignored port={_port} reason={ex.GetType().Name}");
+                    this.Logger.LogDebug(ex, "[NW.UdpListenerBase:Dispose] cts-dispose-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(ex,
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Dispose)}] " +
-                        $"cts-dispose-failed port={_port}");
+                    this.Logger.LogWarning(ex, "[NW.UdpListenerBase:Dispose] cts-dispose-failed port={Port}", _port);
                 }
             }
 
@@ -232,18 +229,14 @@ public abstract partial class UdpListenerBase
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug(
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Dispose)}] " +
-                        $"socket-dispose-ignored port={_port} reason={ex.GetType().Name}");
+                    this.Logger.LogDebug(ex, "[NW.UdpListenerBase:Dispose] socket-dispose-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(ex,
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Dispose)}] " +
-                        $"socket-dispose-failed port={_port}");
+                    this.Logger.LogWarning(ex, "[NW.UdpListenerBase:Dispose] socket-dispose-failed port={Port}", _port);
                 }
             }
 
@@ -255,7 +248,7 @@ public abstract partial class UdpListenerBase
 
         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
         {
-            this.Logger.LogDebug($"[NW.{nameof(UdpListenerBase)}:{nameof(Dispose)}] disposed port={_port}");
+            this.Logger.LogDebug("[NW.UdpListenerBase:Dispose] disposed port={Port}", _port);
         }
     }
 

--- a/src/Nalix.Network/Listeners/UdpListener/UdpListener.PublicMethods.cs
+++ b/src/Nalix.Network/Listeners/UdpListener/UdpListener.PublicMethods.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -60,9 +60,7 @@ public abstract partial class UdpListenerBase : IListener
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
             {
-                this.Logger.LogWarning(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(Activate)}] " +
-                    $"activate-skipped lock-busy port={_port}");
+                this.Logger.LogWarning("[NW.UdpListenerBase:Activate] activate-skipped lock-busy port={Port}", _port);
             }
             return;
         }
@@ -74,9 +72,7 @@ public abstract partial class UdpListenerBase : IListener
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Activate)}] " +
-                        $"ignored-activate state={this.State}");
+                    this.Logger.LogWarning("[NW.UdpListenerBase:Activate] ignored-activate state={State}", this.State);
                 }
                 return;
             }
@@ -101,9 +97,8 @@ public abstract partial class UdpListenerBase : IListener
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Information))
             {
-                this.Logger.LogInformation(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(Activate)}] " +
-                    $"listening port={_port} protocol={this.Protocol.GetType().Name}");
+                string protocolType = this.Protocol.GetType().Name;
+                this.Logger.LogInformation("[NW.UdpListenerBase:Activate] listening port={Port} protocol={ProtocolType}", _port, protocolType);
             }
 
             // Dispatch parallel SAEA receive workers via TaskManager
@@ -133,9 +128,7 @@ public abstract partial class UdpListenerBase : IListener
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Information))
             {
-                this.Logger.LogInformation(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(Activate)}] " +
-                    $"cancel port={_port}");
+                this.Logger.LogInformation("[NW.UdpListenerBase:Activate] cancel port={Port}", _port);
             }
         }
         catch (SocketException ex)
@@ -144,9 +137,7 @@ public abstract partial class UdpListenerBase : IListener
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Critical))
             {
-                this.Logger.LogCritical(ex,
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(Activate)}] " +
-                    $"bind-fail port={_port}");
+                this.Logger.LogCritical(ex, "[NW.UdpListenerBase:Activate] bind-fail port={Port}", _port);
             }
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
@@ -155,9 +146,7 @@ public abstract partial class UdpListenerBase : IListener
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Critical))
             {
-                this.Logger.LogCritical(ex,
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(Activate)}] " +
-                    $"critical port={_port}");
+                this.Logger.LogCritical(ex, "[NW.UdpListenerBase:Activate] critical port={Port}", _port);
             }
         }
         finally
@@ -198,9 +187,7 @@ public abstract partial class UdpListenerBase : IListener
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"ignored-deactivate state={this.State}");
+                    this.Logger.LogWarning("[NW.UdpListenerBase:Deactivate] ignored-deactivate state={State}", this.State);
                 }
                 return;
             }
@@ -218,18 +205,14 @@ public abstract partial class UdpListenerBase : IListener
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug(
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"cts-cancel-ignored port={_port} reason={ex.GetType().Name}");
+                    this.Logger.LogDebug(ex, "[NW.UdpListenerBase:Deactivate] cts-cancel-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(ex,
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"cts-cancel-failed port={_port}");
+                    this.Logger.LogWarning(ex, "[NW.UdpListenerBase:Deactivate] cts-cancel-failed port={Port}", _port);
                 }
             }
 
@@ -242,18 +225,14 @@ public abstract partial class UdpListenerBase : IListener
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug(
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"socket-close-ignored port={_port} reason={ex.GetType().Name}");
+                    this.Logger.LogDebug(ex, "[NW.UdpListenerBase:Deactivate] socket-close-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(ex,
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"socket-close-failed port={_port}");
+                    this.Logger.LogWarning(ex, "[NW.UdpListenerBase:Deactivate] socket-close-failed port={Port}", _port);
                 }
             }
 
@@ -270,18 +249,14 @@ public abstract partial class UdpListenerBase : IListener
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Information))
             {
-                this.Logger.LogInformation(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(Deactivate)}] " +
-                    $"stopped port={_port}");
+                this.Logger.LogInformation("[NW.UdpListenerBase:Deactivate] stopped port={Port}", _port);
             }
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
             {
-                this.Logger.LogError(ex,
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(Deactivate)}] " +
-                    $"stop-error port={_port}");
+                this.Logger.LogError(ex, "[NW.UdpListenerBase:Deactivate] stop-error port={Port}", _port);
             }
         }
         finally
@@ -294,18 +269,14 @@ public abstract partial class UdpListenerBase : IListener
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug(
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"cts-dispose-ignored port={_port} reason={ex.GetType().Name}");
+                    this.Logger.LogDebug(ex, "[NW.UdpListenerBase:Deactivate] cts-dispose-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(ex,
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"cts-dispose-failed port={_port}");
+                    this.Logger.LogWarning(ex, "[NW.UdpListenerBase:Deactivate] cts-dispose-failed port={Port}", _port);
                 }
             }
 
@@ -317,18 +288,14 @@ public abstract partial class UdpListenerBase : IListener
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug(
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"rate-limiter-dispose-ignored port={_port} reason={ex.GetType().Name}");
+                    this.Logger.LogDebug(ex, "[NW.UdpListenerBase:Deactivate] rate-limiter-dispose-ignored port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logger.LogWarning(ex,
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Deactivate)}] " +
-                        $"rate-limiter-dispose-failed port={_port}");
+                    this.Logger.LogWarning(ex, "[NW.UdpListenerBase:Deactivate] rate-limiter-dispose-failed port={Port}", _port);
                 }
             }
 

--- a/src/Nalix.Network/Listeners/UdpListener/UdpListener.Receive.cs
+++ b/src/Nalix.Network/Listeners/UdpListener/UdpListener.Receive.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -105,9 +105,7 @@ public abstract partial class UdpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
             {
-                this.Logger.LogDebug(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(StartReceive)}] " +
-                    $"disposed-or-cancelled port={_port} reason={ex.GetType().Name}");
+                this.Logger.LogDebug(ex, "[NW.UdpListenerBase:StartReceive] disposed-or-cancelled port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
             }
         }
         catch (ObjectDisposedException ex)
@@ -116,7 +114,7 @@ public abstract partial class UdpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
             {
-                this.Logger.LogError(ex, $"[NW.{nameof(UdpListenerBase)}:{nameof(StartReceive)}] recv-object-disposed port={_port}");
+                this.Logger.LogError(ex, "[NW.UdpListenerBase:StartReceive] recv-object-disposed port={Port}", _port);
             }
         }
         catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
@@ -125,7 +123,7 @@ public abstract partial class UdpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
             {
-                this.Logger.LogError(ex, $"[NW.{nameof(UdpListenerBase)}:{nameof(StartReceive)}] recv-error port={_port}");
+                this.Logger.LogError(ex, "[NW.UdpListenerBase:StartReceive] recv-error port={Port}", _port);
             }
 
             // Brief delay to prevent tight error loops on synchronous failure.
@@ -155,9 +153,7 @@ public abstract partial class UdpListenerBase
                 _ = Interlocked.Increment(ref self._recvErrors);
                 if (self.Logger != null && self.Logger.IsEnabled(LogLevel.Error))
                 {
-                    self.Logger.LogError(
-                        error,
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(RetryStartReceiveAsync)}] retry-failed port={self._port}");
+                    self.Logger.LogError(error, "[NW.UdpListenerBase:RetryStartReceiveAsync] retry-failed port={Port}", self._port);
                 }
             }
         }, this, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
@@ -202,21 +198,21 @@ public abstract partial class UdpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
             {
-                this.Logger.LogError(ex, $"[NW.{nameof(UdpListenerBase)}:{nameof(OnReceiveCompleted)}] handle-error port={_port}");
+                this.Logger.LogError(ex, "[NW.UdpListenerBase:OnReceiveCompleted] handle-error port={Port}", _port);
             }
         }
         catch (ObjectDisposedException ex)
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
             {
-                this.Logger.LogError(ex, $"[NW.{nameof(UdpListenerBase)}:{nameof(OnReceiveCompleted)}] handle-error port={_port}");
+                this.Logger.LogError(ex, "[NW.UdpListenerBase:OnReceiveCompleted] handle-error port={Port}", _port);
             }
         }
         catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
             {
-                this.Logger.LogError(ex, $"[NW.{nameof(UdpListenerBase)}:{nameof(OnReceiveCompleted)}] handle-error port={_port}");
+                this.Logger.LogError(ex, "[NW.UdpListenerBase:OnReceiveCompleted] handle-error port={Port}", _port);
             }
         }
         finally
@@ -248,9 +244,7 @@ public abstract partial class UdpListenerBase
 
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
                 {
-                    this.Logger.LogTrace(
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(HandleReceive)}] " +
-                        $"rate-limit-drop remote={ip}");
+                    this.Logger.LogTrace("[NW.UdpListenerBase:HandleReceive] rate-limit-drop remote={Ip}", ip);
                 }
 
                 return;
@@ -262,9 +256,7 @@ public abstract partial class UdpListenerBase
 
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
                 {
-                    this.Logger.LogTrace(
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(HandleReceive)}] " +
-                        $"oversize-drop remote={args.RemoteEndPoint} size={args.BytesTransferred}");
+                    this.Logger.LogTrace("[NW.UdpListenerBase:HandleReceive] oversize-drop remote={ArgsRemoteEndPoint} size={ArgsBytesTransferred}", args.RemoteEndPoint, args.BytesTransferred);
                 }
 
                 return;
@@ -286,7 +278,7 @@ public abstract partial class UdpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
             {
-                this.Logger?.LogDebug(ex, $"[NW.UdpListenerBase:{nameof(HandleReceive)}] non-fatal");
+                this.Logger?.LogDebug(ex, "[NW.UdpListenerBase:HandleReceive] non-fatal");
             }
         }
     }
@@ -319,9 +311,7 @@ public abstract partial class UdpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(ProcessDatagram)}] " +
-                    $"short-packet-drop remote={remoteEndPoint} len={lease?.Length}");
+                this.Logger.LogTrace("[NW.UdpListenerBase:ProcessDatagram] short-packet-drop remote={RemoteEndPoint} len={LeaseLength}", remoteEndPoint, lease?.Length);
             }
 
             lease?.Dispose();
@@ -341,9 +331,7 @@ public abstract partial class UdpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(ProcessDatagram)}] " +
-                    $"short-packet-drop remote={remoteEndPoint} payloadLen={payload.Length}");
+                this.Logger.LogTrace("[NW.UdpListenerBase:ProcessDatagram] short-packet-drop remote={RemoteEndPoint} payloadLen={PayloadLength}", remoteEndPoint, payload.Length);
             }
 
             lease.Dispose();
@@ -358,9 +346,7 @@ public abstract partial class UdpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(ProcessDatagram)}] " +
-                    $"invalid-flags-drop remote={remoteEndPoint} flags={header.Flags}");
+                this.Logger.LogTrace("[NW.UdpListenerBase:ProcessDatagram] invalid-flags-drop remote={RemoteEndPoint} flags={HeaderFlags}", remoteEndPoint, header.Flags);
             }
 
             lease.Dispose();
@@ -379,9 +365,7 @@ public abstract partial class UdpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(ProcessDatagram)}] " +
-                    $"unknown-token-drop remote={remoteEndPoint}");
+                this.Logger.LogTrace("[NW.UdpListenerBase:ProcessDatagram] unknown-token-drop remote={RemoteEndPoint}", remoteEndPoint);
             }
 
             lease.Dispose();
@@ -397,9 +381,7 @@ public abstract partial class UdpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(ProcessDatagram)}] " +
-                    $"endpoint-mismatch-drop expected={connection.NetworkEndpoint} actual={remoteEndPoint} connId={connection.ID}");
+                this.Logger.LogTrace("[NW.UdpListenerBase:ProcessDatagram] endpoint-mismatch-drop expected={ConnectionNetworkEndpoint} actual={RemoteEndPoint} connId={ConnectionId}", connection.NetworkEndpoint, remoteEndPoint, connection.ID);
             }
 
             lease.Dispose();
@@ -414,9 +396,7 @@ public abstract partial class UdpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(ProcessDatagram)}] " +
-                    $"replay-window-drop seq={header.SequenceId} connId={connection.ID}");
+                this.Logger.LogTrace("[NW.UdpListenerBase:ProcessDatagram] replay-window-drop seq={HeaderSequenceId} connId={ConnectionId}", header.SequenceId, connection.ID);
             }
 
             lease.Dispose();
@@ -430,9 +410,7 @@ public abstract partial class UdpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(ProcessDatagram)}] " +
-                    $"unauth-drop remote={remoteEndPoint} connId={connection.ID}");
+                this.Logger.LogTrace("[NW.UdpListenerBase:ProcessDatagram] unauth-drop remote={RemoteEndPoint} connId={ConnectionId}", remoteEndPoint, connection.ID);
             }
 
             lease.Dispose();
@@ -475,9 +453,7 @@ public abstract partial class UdpListenerBase
 
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace(
-                    $"[NW.{nameof(UdpListenerBase)}:{nameof(ProcessDatagram)}] " +
-                    $"accepted connId={connection.ID} ep={remoteEndPoint} payloadSize={incomingLease.Length}");
+                this.Logger.LogTrace("[NW.UdpListenerBase:ProcessDatagram] accepted connId={ConnectionId} ep={RemoteEndPoint} payloadSize={IncomingLeaseLength}", connection.ID, remoteEndPoint, incomingLease.Length);
             }
         }
         finally

--- a/src/Nalix.Network/Listeners/UdpListener/UdpListener.SocketConfig.cs
+++ b/src/Nalix.Network/Listeners/UdpListener/UdpListener.SocketConfig.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -40,9 +40,7 @@ public abstract partial class UdpListenerBase
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logger.LogDebug(
-                        $"[NW.{nameof(UdpListenerBase)}:{nameof(Initialize)}] " +
-                        $"dualmode-not-applied port={_port} reason={ex.GetType().Name}");
+                    this.Logger.LogDebug(ex, "[NW.UdpListenerBase:Initialize] dualmode-not-applied port={Port} reason={ExceptionType}", _port, ex.GetType().Name);
                 }
             }
         }
@@ -58,9 +56,7 @@ public abstract partial class UdpListenerBase
 
         if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Debug))
         {
-            this.Logger.LogDebug(
-                $"[NW.{nameof(UdpListenerBase)}:{nameof(Initialize)}] " +
-                $"init-ok port={_port} af={af} reuse={_options.ReuseAddress} buf={_options.BufferSize}");
+            this.Logger.LogDebug("[NW.UdpListenerBase:Initialize] init-ok port={Port} af={Af} reuse={OptionsReuseAddress} buf={OptionsBufferSize}", _port, af, _options.ReuseAddress, _options.BufferSize);
         }
     }
 

--- a/src/Nalix.Network/Listeners/UdpListener/UdpPassthroughListener.cs
+++ b/src/Nalix.Network/Listeners/UdpListener/UdpPassthroughListener.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -133,9 +133,7 @@ public sealed class UdpPassthroughListener : UdpListenerBase
         {
             if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Trace))
             {
-                this.Logger.LogTrace(
-                    $"[NW.{nameof(UdpPassthroughListener)}:{nameof(ProcessDatagram)}] " +
-                    $"rate-limit-drop remote={ipEndPoint}");
+                this.Logger.LogTrace("[NW.UdpPassthroughListener:ProcessDatagram] rate-limit-drop remote={IpEndPoint}", ipEndPoint);
             }
 
             lease.Dispose();

--- a/src/Nalix.Network/Listeners/WebListener/WebSocketListener.Core.cs
+++ b/src/Nalix.Network/Listeners/WebListener/WebSocketListener.Core.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -185,7 +185,7 @@ public abstract partial class WebSocketListenerBase : IListener
 
                 if (_logger != null && _logger.IsEnabled(LogLevel.Information))
                 {
-                    _logger.LogInformation($"[NW.{nameof(WebSocketListenerBase)}:{nameof(SCHEDULE_STOP)}] stopped port={self._port}");
+                    _logger.LogInformation("[NW.WebSocketListenerBase:SCHEDULE_STOP] stopped port={Port}", self._port);
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex)) { }
@@ -278,7 +278,7 @@ public abstract partial class WebSocketListenerBase : IListener
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug($"[NW.{nameof(WebSocketListenerBase)}:{nameof(Dispose)}] disposed");
+            _logger.LogDebug("[NW.WebSocketListenerBase:Dispose] disposed");
         }
     }
 

--- a/src/Nalix.Network/Listeners/WebListener/WebSocketListener.Handle.cs
+++ b/src/Nalix.Network/Listeners/WebListener/WebSocketListener.Handle.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -78,14 +78,14 @@ public abstract partial class WebSocketListenerBase
 
             if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.LogTrace($"[NW.{nameof(WebSocketListenerBase)}:{nameof(ProcessConnection)}] new={connection?.NetworkEndpoint}");
+                _logger.LogTrace("[NW.WebSocketListenerBase:ProcessConnection] new={RemoteEndpoint}", connection?.NetworkEndpoint);
             }
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[NW.{nameof(WebSocketListenerBase)}:{nameof(ProcessConnection)}] process-error={connection?.NetworkEndpoint}");
+                _logger.LogError(ex, "[NW.WebSocketListenerBase:ProcessConnection] process-error={RemoteEndpoint}", connection?.NetworkEndpoint);
             }
             connection?.Dispose();
         }
@@ -121,7 +121,7 @@ public abstract partial class WebSocketListenerBase
                     {
                         if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
                         {
-                            _logger.LogWarning($"[NW.{nameof(WebSocketListenerBase)}:{nameof(AcceptConnectionsAsync)}] untrusted-proxy-rejected remote={remoteEp}");
+                            _logger.LogWarning("[NW.WebSocketListenerBase:AcceptConnectionsAsync] untrusted-proxy-rejected remote={RemoteEndpoint}", remoteEp);
                         }
 
                         context.Response.StatusCode = 403; // Forbidden
@@ -170,7 +170,7 @@ public abstract partial class WebSocketListenerBase
                     {
                         if (_logger != null && _logger.IsEnabled(LogLevel.Error))
                         {
-                            _logger.LogError(ex, $"[NW.{nameof(WebSocketListenerBase)}] Failed to initialize connection");
+                            _logger.LogError(ex, "[NW.WebSocketListenerBase] Failed to initialize connection");
                         }
                         connection.Dispose();
                     }
@@ -279,7 +279,7 @@ public abstract partial class WebSocketListenerBase
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[NW.{nameof(WebSocketListenerBase)}:{nameof(PROCESS_CHANNEL_LOOP_ASYNC)}] unhandled-error port={_port}");
+                _logger.LogError(ex, "[NW.WebSocketListenerBase:PROCESS_CHANNEL_LOOP_ASYNC] unhandled-error port={Port}", _port);
             }
         }
         finally
@@ -307,7 +307,7 @@ public abstract partial class WebSocketListenerBase
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[NW.{nameof(WebSocketListenerBase)}:{nameof(INVOKE_PROCESS)}] error remote={connection?.NetworkEndpoint.ToString() ?? "<null>"} port={_port}");
+                _logger.LogError(ex, "[NW.WebSocketListenerBase:INVOKE_PROCESS] error remote={RemoteEndpoint}", connection?.NetworkEndpoint.ToString() ?? "<null>");
             }
             connection?.Disconnect();
         }

--- a/src/Nalix.Network/Listeners/WebListener/WebSocketListener.PublicMethods.cs
+++ b/src/Nalix.Network/Listeners/WebListener/WebSocketListener.PublicMethods.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -32,16 +32,14 @@ public abstract partial class WebSocketListenerBase
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug($"[NW.{nameof(WebSocketListenerBase)}:{nameof(Activate)}] activate-request port={_port}");
+            _logger.LogDebug("[NW.WebSocketListenerBase:Activate] activate-request port={Port}", _port);
         }
 
         if (!_lock.Wait(0, CancellationToken.None))
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning(
-                    $"[NW.{nameof(WebSocketListenerBase)}:{nameof(Activate)}] " +
-                    $"activate-skipped lock-busy port={_port}");
+                _logger.LogWarning("[NW.WebSocketListenerBase:Activate] activate-skipped lock-busy port={Port}", _port);
             }
             return;
         }
@@ -54,7 +52,7 @@ public abstract partial class WebSocketListenerBase
             {
                 if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
                 {
-                    _logger.LogWarning($"[NW.{nameof(WebSocketListenerBase)}:{nameof(Activate)}] ignored-activate state={this.State}");
+                    _logger.LogWarning("[NW.WebSocketListenerBase:Activate] ignored-activate state={State}", this.State);
                 }
                 return;
             }
@@ -84,7 +82,7 @@ public abstract partial class WebSocketListenerBase
 
             if (_logger != null && _logger.IsEnabled(LogLevel.Information))
             {
-                _logger.LogInformation($"[NW.{nameof(WebSocketListenerBase)}:{nameof(Activate)}] start protocol={_protocol} port={_port} path={_path}");
+                _logger.LogInformation("[NW.WebSocketListenerBase:Activate] start protocol={Protocol} port={Port} path={Path}", _protocol, _port, _path);
             }
 
             if (_config.EnableTimeout)
@@ -123,7 +121,7 @@ public abstract partial class WebSocketListenerBase
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Information))
             {
-                _logger.LogInformation($"[NW.{nameof(WebSocketListenerBase)}:{nameof(Activate)}] cancel port={_port}");
+                _logger.LogInformation("[NW.WebSocketListenerBase:Activate] cancel port={Port}", _port);
             }
             _ = Interlocked.Exchange(ref _state, (int)ListenerState.STOPPED);
         }
@@ -131,7 +129,7 @@ public abstract partial class WebSocketListenerBase
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Critical))
             {
-                _logger.LogCritical(ex, $"[NW.{nameof(WebSocketListenerBase)}:{nameof(Activate)}] critical-error port={_port}");
+                _logger.LogCritical(ex, "[NW.WebSocketListenerBase:Activate] critical-error port={Port}", _port);
             }
             _ = Interlocked.Exchange(ref _state, (int)ListenerState.STOPPED);
         }
@@ -154,7 +152,7 @@ public abstract partial class WebSocketListenerBase
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug($"[NW.{nameof(WebSocketListenerBase)}:{nameof(Deactivate)}] deactivate-request port={_port}");
+            _logger.LogDebug("[NW.WebSocketListenerBase:Deactivate] deactivate-request port={Port}", _port);
         }
 
         int prev = Interlocked.CompareExchange(ref _state, (int)ListenerState.STOPPING, (int)ListenerState.RUNNING);
@@ -202,7 +200,7 @@ public abstract partial class WebSocketListenerBase
 
             if (_logger != null && _logger.IsEnabled(LogLevel.Information))
             {
-                _logger.LogInformation($"[NW.{nameof(WebSocketListenerBase)}:{nameof(Deactivate)}] stop protocol={_protocol} port={_port}");
+                _logger.LogInformation("[NW.WebSocketListenerBase:Deactivate] stop protocol={Protocol} port={Port}", _protocol, _port);
             }
         }
         finally
@@ -240,7 +238,7 @@ public abstract partial class WebSocketListenerBase
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug($"[NW.{nameof(WebSocketListenerBase)}:{nameof(Initialize)}] bound to {prefix}");
+            _logger.LogDebug("[NW.WebSocketListenerBase:Initialize] bound to {Prefix}", prefix);
         }
     }
 

--- a/src/Nalix.Network/Options/NetworkCallbackOptions.cs
+++ b/src/Nalix.Network/Options/NetworkCallbackOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using Nalix.Abstractions;
@@ -127,16 +127,14 @@ public sealed partial class NetworkCallbackOptions : ConfigurationLoader, IValid
         if (this.CallbackWarningThreshold > 0 && this.CallbackWarningThreshold >= this.MaxPendingNormalCallbacks)
         {
             throw new System.ArgumentException(
-                $"{nameof(this.CallbackWarningThreshold)} ({this.CallbackWarningThreshold}) " +
-                $"must be less than {nameof(this.MaxPendingNormalCallbacks)} ({this.MaxPendingNormalCallbacks}).");
+                $"{nameof(this.CallbackWarningThreshold)} ({this.CallbackWarningThreshold}) must be less than {nameof(this.MaxPendingNormalCallbacks)} ({this.MaxPendingNormalCallbacks}).");
         }
 
         // Cross-field guard: per-IP cap should not exceed global cap
         if (this.MaxPendingPerIp > this.MaxPendingNormalCallbacks)
         {
             throw new System.ArgumentException(
-                $"{nameof(this.MaxPendingPerIp)} ({this.MaxPendingPerIp}) " +
-                $"must not exceed {nameof(this.MaxPendingNormalCallbacks)} ({this.MaxPendingNormalCallbacks}).");
+                $"{nameof(this.MaxPendingPerIp)} ({this.MaxPendingPerIp}) must not exceed {nameof(this.MaxPendingNormalCallbacks)} ({this.MaxPendingNormalCallbacks}).");
         }
     }
 }

--- a/src/Nalix.Network/Protocols/Protocol.Core.cs
+++ b/src/Nalix.Network/Protocols/Protocol.Core.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -72,7 +72,7 @@ public abstract partial class Protocol : IProtocol
 
                 if (s_logger != null && s_logger.IsEnabled(LogLevel.Trace))
                 {
-                    s_logger.LogTrace($"[NW.{nameof(Protocol)}:{nameof(PostProcessMessage)}] disconnect id={args.Connection?.ID}");
+                    s_logger.LogTrace("[NW.Protocol:PostProcessMessage] disconnect id={ArgsConnectionID}", args.Connection?.ID);
                 }
             }
         }
@@ -104,7 +104,8 @@ public abstract partial class Protocol : IProtocol
 
         if (s_logger != null && s_logger.IsEnabled(LogLevel.Information))
         {
-            s_logger.LogInformation($"[NW.{nameof(Protocol)}:{nameof(SetConnectionAcceptance)}] accepting={(isEnabled ? "enabled" : "disabled")}");
+            string state = isEnabled ? "enabled" : "disabled";
+            s_logger.LogInformation("[NW.Protocol:SetConnectionAcceptance] accepting={State}", state);
         }
     }
 }

--- a/src/Nalix.Network/Protocols/Protocol.Lifecycle.cs
+++ b/src/Nalix.Network/Protocols/Protocol.Lifecycle.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -69,7 +69,7 @@ public abstract partial class Protocol
 
         if (s_logger != null && s_logger.IsEnabled(LogLevel.Trace))
         {
-            s_logger.LogTrace($"[NW.{nameof(Protocol)}:{nameof(Dispose)}] disposed");
+            s_logger.LogTrace("[NW.Protocol:Dispose] disposed");
         }
 
         // Derived protocols can release managed resources when disposing == true.

--- a/src/Nalix.Network/Protocols/Protocol.PublicMethods.cs
+++ b/src/Nalix.Network/Protocols/Protocol.PublicMethods.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -61,7 +61,7 @@ public abstract partial class Protocol
         {
             if (s_logger != null && s_logger.IsEnabled(LogLevel.Trace))
             {
-                s_logger.LogTrace($"[NW.{nameof(Protocol)}:{nameof(OnAccept)}] reject id={connection.ID} reason=not-accepting");
+                s_logger.LogTrace("[NW.Protocol:OnAccept] reject id={ConnectionId} reason=not-accepting", connection.ID);
             }
             connection.Disconnect();
             return;
@@ -79,7 +79,7 @@ public abstract partial class Protocol
             {
                 if (s_logger != null && s_logger.IsEnabled(LogLevel.Trace))
                 {
-                    s_logger.LogTrace($"[NW.{nameof(Protocol)}:{nameof(OnAccept)}] accepted id={connection.ID}");
+                    s_logger.LogTrace("[NW.Protocol:OnAccept] accepted id={ConnectionId}", connection.ID);
                 }
 
                 connection.TCP.UseFraming(this.Framing);
@@ -92,7 +92,7 @@ public abstract partial class Protocol
 
             if (s_logger != null && s_logger.IsEnabled(LogLevel.Trace))
             {
-                s_logger.LogTrace($"[NW.{nameof(Protocol)}:{nameof(OnAccept)}] reject id={connection.ID} reason=validation-failed");
+                s_logger.LogTrace("[NW.Protocol:OnAccept] reject id={ConnectionId} reason=validation-failed", connection.ID);
             }
 
             // Connections failed validation, close immediately
@@ -102,7 +102,7 @@ public abstract partial class Protocol
         {
             if (s_logger != null && s_logger.IsEnabled(LogLevel.Trace))
             {
-                s_logger.LogTrace($"[NW.{nameof(Protocol)}:{nameof(OnAccept)}] accept-canceled id={connection.ID}");
+                s_logger.LogTrace("[NW.Protocol:OnAccept] accept-canceled id={ConnectionId}", connection.ID);
             }
             connection.Disconnect();
         }
@@ -113,7 +113,7 @@ public abstract partial class Protocol
             {
                 if (s_logger != null && s_logger.IsEnabled(LogLevel.Warning))
                 {
-                    s_logger.LogWarning($"[NW.{nameof(Protocol)}:{nameof(OnAccept)}] accept-disposed id={connection.ID} target={ex.ObjectName}");
+                    s_logger.LogWarning(ex, "[NW.Protocol:OnAccept] accept-disposed id={ConnectionId} target={Target}", connection.ID, ex.ObjectName);
                 }
             }
 
@@ -127,7 +127,7 @@ public abstract partial class Protocol
 
             if (s_logger != null && s_logger.IsEnabled(LogLevel.Debug))
             {
-                s_logger.LogDebug($"[NW.{nameof(Protocol)}:{nameof(OnAccept)}] accept-error id={connection.ID} ex={ex.Message}");
+                s_logger.LogDebug(ex, "[NW.Protocol:OnAccept] accept-error id={ConnectionId}", connection.ID);
             }
         }
     }

--- a/src/Nalix.Network/RateLimiting/Connection.Guard.Cleanup.cs
+++ b/src/Nalix.Network/RateLimiting/Connection.Guard.Cleanup.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -167,7 +167,7 @@ public sealed partial class ConnectionGuard
             {
                 if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug($"[NW.{nameof(ConnectionGuard)}] cleanup scanned={scanned} removed={removed} remaining={_map.Count}");
+                    _logger.LogDebug("[NW.ConnectionGuard] cleanup scanned={Scanned} removed={Removed} remaining={MapCount}", scanned, removed, _map.Count);
                 }
             }
         }
@@ -175,7 +175,7 @@ public sealed partial class ConnectionGuard
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[NW.{nameof(ConnectionGuard)}] cleanup-error");
+                _logger.LogError(ex, "[NW.ConnectionGuard] cleanup-error");
             }
         }
     }

--- a/src/Nalix.Network/RateLimiting/Connection.Guard.cs
+++ b/src/Nalix.Network/RateLimiting/Connection.Guard.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -119,10 +119,7 @@ public sealed partial class ConnectionGuard : IDisposable, IAsyncDisposable, IRe
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug($"[NW.{nameof(ConnectionGuard)}] init " +
-                             $"maxPerEndpoint={_maxPerEndpoint} " +
-                             $"inactivity={_inactivityThreshold.TotalSeconds:F0}s " +
-                             $"cleanup={_cleanupInterval.TotalSeconds:F0}s");
+            _logger.LogDebug("[NW.ConnectionGuard] init maxPerEndpoint={Limit} inactivity={InactivityThresholdTotalSeconds}s cleanup={CleanupIntervalTotalSeconds}s", _maxPerEndpoint, _inactivityThreshold.TotalSeconds, _cleanupInterval.TotalSeconds);
         }
     }
 
@@ -178,7 +175,8 @@ public sealed partial class ConnectionGuard : IDisposable, IAsyncDisposable, IRe
         if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
         {
             DateTime banUntil = new(banUntilTicks, DateTimeKind.Utc);
-            _logger.LogWarning($"[NW.ConnectionGuard] manually-banned ip={address} until={banUntil:HH:mm:ss}");
+            string banTime = banUntil.ToString("HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture);
+            _logger.LogWarning("[NW.ConnectionGuard] manually-banned ip={Address} until={BanUntil}", address, banTime);
         }
     }
 
@@ -252,9 +250,7 @@ public sealed partial class ConnectionGuard : IDisposable, IAsyncDisposable, IRe
 
                     if (_logger != null && _logger.IsEnabled(LogLevel.Information))
                     {
-                        _logger.LogInformation(
-                            $"[NW.{nameof(ConnectionGuard)}] reject endpoint={endPoint} " +
-                            $"current={result.CurrentConnections} limit={_maxPerEndpoint}{suffix}");
+                        _logger.LogInformation("[NW.ConnectionGuard] reject endpoint={Endpoint} current={Current} limit={Limit}{Suffix}", endPoint, result.CurrentConnections, _maxPerEndpoint, suffix);
                     }
                 }
             }
@@ -263,7 +259,7 @@ public sealed partial class ConnectionGuard : IDisposable, IAsyncDisposable, IRe
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.LogTrace($"[NW.{nameof(ConnectionGuard)}] allow endpoint={endPoint} current={result.CurrentConnections} limit={_maxPerEndpoint}");
+                _logger.LogTrace("[NW.ConnectionGuard] allow endpoint={Endpoint} current={Current} limit={Limit}", endPoint, result.CurrentConnections, _maxPerEndpoint);
             }
         }
 
@@ -288,7 +284,7 @@ public sealed partial class ConnectionGuard : IDisposable, IAsyncDisposable, IRe
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning($"[NW.{nameof(ConnectionGuard)}:Internal] received-null args/connection/endpoint");
+                _logger.LogWarning("[NW.ConnectionGuard:Internal] received-null args/connection/endpoint");
             }
             return;
         }
@@ -297,7 +293,7 @@ public sealed partial class ConnectionGuard : IDisposable, IAsyncDisposable, IRe
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning($"[NW.{nameof(ConnectionGuard)}:Internal] received-empty-address");
+                _logger.LogWarning("[NW.ConnectionGuard:Internal] received-empty-address");
             }
             return;
         }
@@ -326,7 +322,7 @@ public sealed partial class ConnectionGuard : IDisposable, IAsyncDisposable, IRe
 
                 if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
                 {
-                    _logger.LogTrace($"[NW.{nameof(ConnectionGuard)}] closed endpoint={key.Address}{suffix}");
+                    _logger.LogTrace("[NW.ConnectionGuard] closed endpoint={Address}{Suffix}", key.Address, suffix);
                 }
             }
         }
@@ -430,7 +426,8 @@ public sealed partial class ConnectionGuard : IDisposable, IAsyncDisposable, IRe
                         if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
                         {
                             DateTime banUntil = new(banUntilTicks, DateTimeKind.Utc);
-                            _logger.LogWarning($"[NW.{nameof(ConnectionGuard)}] banned ip={key.Address} count={entry.BanCount} until={banUntil:HH:mm:ss}");
+                            string banTime = banUntil.ToString("HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture);
+                            _logger.LogWarning("[NW.ConnectionGuard] banned ip={Address} count={BanCount} until={BanUntil}", key.Address, entry.BanCount, banTime);
                         }
                     }
 
@@ -569,7 +566,7 @@ public sealed partial class ConnectionGuard : IDisposable, IAsyncDisposable, IRe
 
                 if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug($"[NW.{nameof(ConnectionGuard)}] cleared-queue ip={key.Address} reason=oversized");
+                    _logger.LogDebug("[NW.ConnectionGuard] cleared-queue ip={Address} reason=oversized", key.Address);
                 }
             }
 
@@ -612,14 +609,14 @@ public sealed partial class ConnectionGuard : IDisposable, IAsyncDisposable, IRe
 
             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug($"[NW.{nameof(ConnectionGuard)}:{nameof(Dispose)}] disposed");
+                _logger.LogDebug("[NW.ConnectionGuard:Dispose] disposed");
             }
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[NW.{nameof(ConnectionGuard)}:{nameof(Dispose)}] dispose-error");
+                _logger.LogError(ex, "[NW.ConnectionGuard:Dispose] dispose-error");
             }
         }
 

--- a/src/Nalix.Network/RateLimiting/Datagram.Guard.cs
+++ b/src/Nalix.Network/RateLimiting/Datagram.Guard.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -117,7 +117,7 @@ public sealed class DatagramGuard : IDisposable, IWithLogging<DatagramGuard>
             {
                 if (self._logger != null && self._logger.IsEnabled(LogLevel.Error))
                 {
-                    self._logger.LogError(ex, $"[NW.{nameof(DatagramGuard)}] cleanup-loop-faulted");
+                    self._logger.LogError(ex, "[NW.DatagramGuard] cleanup-loop-faulted");
                 }
             }
         }, this, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
@@ -253,14 +253,14 @@ public sealed class DatagramGuard : IDisposable, IWithLogging<DatagramGuard>
             {
                 if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
                 {
-                    _logger.LogWarning(ex, $"[NW.{nameof(DatagramGuard)}] Cleanup error.");
+                    _logger.LogWarning(ex, "[NW.DatagramGuard] Cleanup error.");
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 if (_logger != null && _logger.IsEnabled(LogLevel.Error))
                 {
-                    _logger.LogError(ex, $"[NW.{nameof(DatagramGuard)}] Unexpected error in CleanupLoopAsync.");
+                    _logger.LogError(ex, "[NW.DatagramGuard] Unexpected error in CleanupLoopAsync.");
                 }
             }
         }
@@ -297,7 +297,7 @@ public sealed class DatagramGuard : IDisposable, IWithLogging<DatagramGuard>
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug($"[NW.{nameof(DatagramGuard)}] Evicted {removed} idle windows. IPv4={_ipv4Map.Count}, IPv6={_ipv6Map.Count}");
+                _logger.LogDebug("[NW.DatagramGuard] Evicted {Removed} idle windows. IPv4={Ipv4MapCount}, IPv6={Ipv6MapCount}", removed, _ipv4Map.Count, _ipv6Map.Count);
             }
         }
     }
@@ -322,7 +322,7 @@ public sealed class DatagramGuard : IDisposable, IWithLogging<DatagramGuard>
             {
                 if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug(ex, $"[NW.{nameof(DatagramGuard)}] cleanup-task-completed-with-error during dispose");
+                    _logger.LogDebug(ex, "[NW.DatagramGuard] cleanup-task-completed-with-error during dispose");
                 }
             }
         }

--- a/src/Nalix.Runtime/Dispatching/Options/PacketDispatchOptions.Execution.cs
+++ b/src/Nalix.Runtime/Dispatching/Options/PacketDispatchOptions.Execution.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -41,10 +41,8 @@ public sealed partial class PacketDispatchOptions<TPacket>
 
             if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Debug))
             {
-                this.Logging.LogDebug(
-                    $"[RT.{nameof(PacketDispatchOptions<>)}:{nameof(ExecuteHandlerAsync)}] " +
-                    $"type-mismatch opcode=0x{descriptor.OpCode:X4} " +
-                    $"expected={expectedType.Name} actual={actualType?.Name ?? "null"} — skipping handler");
+                string actualName = actualType?.Name ?? "null";
+                this.Logging.LogDebug("[RT.PacketDispatchOptions:ExecuteHandlerAsync] type-mismatch opcode=0x{OpCode:X4} expected={ExpectedType} actual={ActualType}", descriptor.OpCode, expectedType.Name, actualName);
             }
 
             await this.TrySendControlAsync(
@@ -67,10 +65,7 @@ public sealed partial class PacketDispatchOptions<TPacket>
         {
             if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Warning))
             {
-                this.Logging.LogWarning(
-                    $"[{nameof(PacketDispatchOptions<>)}:{nameof(ExecuteHandlerAsync)}] " +
-                    $"validation-failed opcode=0x{descriptor.OpCode:X4} " +
-                    $"reason={failureReason} — skipping handler");
+                this.Logging.LogWarning("[PacketDispatchOptions:ExecuteHandlerAsync] validation-failed opcode=0x{OpCode} reason={FailureReason} — skipping handler", descriptor.OpCode, failureReason);
             }
 
             await this.TrySendControlAsync(
@@ -187,17 +182,15 @@ public sealed partial class PacketDispatchOptions<TPacket>
         {
             if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Debug))
             {
-                this.Logging.LogDebug(
-                    $"[{nameof(PacketDispatchOptions<>)}:{nameof(HandleDispatchExceptionAsync)}] " +
-                    $"teardown-suppressed opcode={descriptor.OpCode} ex={exception.GetType().Name}");
+                string exceptionType = exception.GetType().Name;
+                this.Logging.LogDebug(exception, "[PacketDispatchOptions:HandleDispatchExceptionAsync] teardown-suppressed opcode={OpCode} ex={ExceptionType}", descriptor.OpCode, exceptionType);
             }
         }
         else
         {
             if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Error))
             {
-                this.Logging.LogError(exception, $"[{nameof(PacketDispatchOptions<>)}:{nameof(HandleDispatchExceptionAsync)}] " +
-                                    $"handler-failed opcode={descriptor.OpCode}");
+                this.Logging.LogError(exception, "[PacketDispatchOptions:HandleDispatchExceptionAsync] handler-failed opcode={OpCode}", descriptor.OpCode);
             }
         }
 
@@ -258,9 +251,7 @@ public sealed partial class PacketDispatchOptions<TPacket>
         {
             if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Debug))
             {
-                this.Logging.LogDebug(
-                    $"[{nameof(PacketDispatchOptions<>)}:{nameof(TrySendControlAsync)}] " +
-                    $"control-send-skipped opcode={opCode} reason={reason} ex={ex.GetType().Name}");
+                this.Logging.LogDebug(ex, "[PacketDispatchOptions:TrySendControlAsync] control-send-skipped opcode={OpCode} reason={Reason} ex={ExceptionType}", opCode, reason, ex.GetType().Name);
             }
         }
     }

--- a/src/Nalix.Runtime/Dispatching/Options/PacketDispatchOptions.PublicMethods.cs
+++ b/src/Nalix.Runtime/Dispatching/Options/PacketDispatchOptions.PublicMethods.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -36,7 +36,7 @@ public sealed partial class PacketDispatchOptions<TPacket>
         this.Logging = logger;
         if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Debug))
         {
-            this.Logging.LogDebug($"[RT.{nameof(PacketDispatchOptions<>)}:{nameof(WithLogging)}] logger-attached");
+            this.Logging.LogDebug("[RT.PacketDispatchOptions:WithLogging] logger-attached");
         }
 
         return this;
@@ -59,7 +59,7 @@ public sealed partial class PacketDispatchOptions<TPacket>
     {
         if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Debug))
         {
-            this.Logging.LogDebug($"[RT.{nameof(PacketDispatchOptions<>)}:{nameof(WithErrorHandling)}] error-handler-set");
+            this.Logging.LogDebug("[RT.PacketDispatchOptions:WithErrorHandling] error-handler-set");
         }
         _errorHandler = errorHandler;
 
@@ -82,7 +82,8 @@ public sealed partial class PacketDispatchOptions<TPacket>
 
         if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Debug))
         {
-            this.Logging.LogDebug($"[RT.{nameof(PacketDispatchOptions<>)}:{nameof(WithMiddleware)}] middleware-added type={middleware.GetType().Name}");
+            string middlewareType = middleware.GetType().Name;
+            this.Logging.LogDebug("[RT.PacketDispatchOptions:WithMiddleware] middleware-added type={MiddlewareType}", middlewareType);
         }
 
         _pipeline.Use(middleware);
@@ -110,7 +111,8 @@ public sealed partial class PacketDispatchOptions<TPacket>
         this.Drain.Count = loopCount ?? 0;
         if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Debug))
         {
-            this.Logging.LogDebug($"[RT.{nameof(PacketDispatchOptions<>)}:{nameof(WithDispatchLoopCount)}] loops={(loopCount.HasValue ? loopCount.Value.ToString(CultureInfo.InvariantCulture) : "auto")}");
+            string loops = loopCount.HasValue ? loopCount.Value.ToString(CultureInfo.InvariantCulture) : "auto";
+            this.Logging.LogDebug("[RT.PacketDispatchOptions:WithDispatchLoopCount] loops={Loops}", loops);
         }
         return this;
     }
@@ -248,17 +250,14 @@ public sealed partial class PacketDispatchOptions<TPacket>
             {
                 if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Debug))
                 {
-                    this.Logging.LogDebug(
-                        $"[RT.{nameof(PacketDispatchOptions<>)}:{nameof(WithHandler)}] " +
-                        $"type-map opcode=0x{descriptor.OpCode:X4} -> {concretePacketType.Name}");
+                    this.Logging.LogDebug("[RT.PacketDispatchOptions:WithHandler] type-map opcode=0x{OpCode} -> {ConcretePacketTypeName}", descriptor.OpCode, concretePacketType.Name);
                 }
             }
         }
 
         if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Information))
         {
-            this.Logging.LogInformation($"[RT.{nameof(PacketDispatchOptions<>)}:{nameof(WithHandler)}] " +
-                               $"reg-handlers count={compiledHandlers.Length} controller={controllerType.Name}");
+            this.Logging.LogInformation("[RT.PacketDispatchOptions:WithHandler] reg-handlers count={CompiledHandlersLength} controller={ControllerTypeName}", compiledHandlers.Length, controllerType.Name);
         }
 
         return this;

--- a/src/Nalix.Runtime/Dispatching/PacketDispatchChannel.cs
+++ b/src/Nalix.Runtime/Dispatching/PacketDispatchChannel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -183,7 +183,7 @@ public sealed class PacketDispatchChannel
         {
             if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Error))
             {
-                this.Logging.LogError(ex, $"[RT.{nameof(PacketDispatchChannel)}:{nameof(Deactivate)}] deactivate-error");
+                this.Logging.LogError(ex, "[RT.PacketDispatchChannel:Deactivate] deactivate-error");
             }
         }
         finally
@@ -196,7 +196,7 @@ public sealed class PacketDispatchChannel
             {
                 if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logging.LogWarning(ex, $"[RT.{nameof(PacketDispatchChannel)}:{nameof(Deactivate)}] linked-cts-dispose-failed");
+                    this.Logging.LogWarning(ex, "[RT.PacketDispatchChannel:Deactivate] linked-cts-dispose-failed");
                 }
             }
 
@@ -208,7 +208,7 @@ public sealed class PacketDispatchChannel
             {
                 if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Warning))
                 {
-                    this.Logging.LogWarning(ex, $"[RT.{nameof(PacketDispatchChannel)}:{nameof(Deactivate)}] local-cts-dispose-failed");
+                    this.Logging.LogWarning(ex, "[RT.PacketDispatchChannel:Deactivate] local-cts-dispose-failed");
                 }
             }
         }
@@ -514,7 +514,7 @@ public sealed class PacketDispatchChannel
         {
             if (this.Logging != null && this.Logging.IsEnabled(LogLevel.Error))
             {
-                this.Logging.LogError(ex, $"[RT.{nameof(PacketDispatchChannel)}:DispatchWorkerLoopAsync] fatal-loop-error index={index}");
+                this.Logging.LogError(ex, "[RT.PacketDispatchChannel:DispatchWorkerLoopAsync] fatal-loop-error index={Index}", index);
             }
         }
         finally

--- a/src/Nalix.Runtime/Dispatching/PacketSender.cs
+++ b/src/Nalix.Runtime/Dispatching/PacketSender.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -101,7 +101,8 @@ public sealed class PacketSender : IPacketSender
 #if DEBUG
         if (s_logger != null && s_logger.IsEnabled(LogLevel.Debug))
         {
-            s_logger.LogDebug($"[RT.PacketSender] Start SEND_CORE_ASYNC | Packet={packet.GetType().Name}, Length={packetLength}, NeedEncrypt={needEncrypt}");
+            string packetType = packet.GetType().Name;
+            s_logger.LogDebug("[RT.PacketSender] Start SEND_CORE_ASYNC | Packet={PacketType}, Length={Length}, NeedEncrypt={NeedEncrypt}", packetType, packetLength, needEncrypt);
         }
 #endif
 

--- a/src/Nalix.Runtime/Internal/Compilation/PacketHandlerCompiler.cs
+++ b/src/Nalix.Runtime/Internal/Compilation/PacketHandlerCompiler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -74,7 +74,7 @@ internal sealed class PacketHandlerCompiler<[DynamicallyAccessedMembers(Dynamica
         ILogger? logger = InstanceManager.Instance.GetExistingInstance<ILogger>();
         if (logger != null && logger.IsEnabled(LogLevel.Debug))
         {
-            logger.LogDebug($"[RT.{nameof(PacketHandlerCompiler<,>)}:{nameof(CompileHandlers)}] scan controller={controllerType.Name}");
+            logger.LogDebug("[RT.PacketHandlerCompiler:CompileHandlers] scan controller={ControllerTypeName}", controllerType.Name);
         }
 
         // Reuse cached method metadata when possible; otherwise compile once and
@@ -109,8 +109,8 @@ internal sealed class PacketHandlerCompiler<[DynamicallyAccessedMembers(Dynamica
 
         if (logger != null && logger.IsEnabled(LogLevel.Debug))
         {
-            logger.LogDebug($"[RT.{nameof(PacketHandlerCompiler<,>)}:{nameof(CompileHandlers)}] " +
-                                   $"found count={compiledMethods.Count} controller={controllerType.FullName} ops=[{firstOps}{(compiledMethods.Count > 6 ? ",..." : string.Empty)}]");
+            string opsSuffix = compiledMethods.Count > 6 ? ",..." : string.Empty;
+            logger.LogDebug("[RT.PacketHandlerCompiler:CompileHandlers] found count={Count} controller={Controller} ops=[{Ops}{Suffix}]", compiledMethods.Count, controllerType.FullName, firstOps, opsSuffix);
         }
 
         return descriptors;
@@ -190,13 +190,13 @@ internal sealed class PacketHandlerCompiler<[DynamicallyAccessedMembers(Dynamica
         {
             if (logger != null && logger.IsEnabled(LogLevel.Debug))
             {
-                logger.LogDebug($"[RT.{nameof(PacketHandlerCompiler<,>)}:Internal] no-method controller={x03.Name}");
+                logger.LogDebug("[RT.PacketHandlerCompiler:Internal] no-method controller={X03Name}", x03.Name);
             }
         }
 
         if (logger != null && logger.IsEnabled(LogLevel.Debug))
         {
-            logger.LogDebug($"[RT.{nameof(PacketHandlerCompiler<,>)}:Internal] compile count={methodInfos.Length} controller={x03.Name}");
+            logger.LogDebug("[RT.PacketHandlerCompiler:Internal] compile count={MethodInfosLength} controller={X03Name}", methodInfos.Length, x03.Name);
         }
 
         return s_compiledMethodCache.GetOrAdd(x03, static (_, methods) =>
@@ -220,7 +220,7 @@ internal sealed class PacketHandlerCompiler<[DynamicallyAccessedMembers(Dynamica
                     ILogger? logger = InstanceManager.Instance.GetExistingInstance<ILogger>();
                     if (logger != null && logger.IsEnabled(LogLevel.Warning))
                     {
-                        logger.LogWarning($"[RT.{nameof(PacketHandlerCompiler<,>)}:Internal] dup-opcode {x01}");
+                        logger.LogWarning("[RT.PacketHandlerCompiler:Internal] dup-opcode {X01}", x01);
                     }
 
                     continue;
@@ -235,7 +235,7 @@ internal sealed class PacketHandlerCompiler<[DynamicallyAccessedMembers(Dynamica
                     ILogger? logger = InstanceManager.Instance.GetExistingInstance<ILogger>();
                     if (logger != null && logger.IsEnabled(LogLevel.Trace))
                     {
-                        logger.LogTrace($"[RT.{nameof(PacketHandlerCompiler<,>)}:Internal] compiled {x01}");
+                        logger.LogTrace("[RT.PacketHandlerCompiler:Internal] compiled {X01}", x01);
                     }
                 }
                 catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
@@ -245,7 +245,7 @@ internal sealed class PacketHandlerCompiler<[DynamicallyAccessedMembers(Dynamica
                     ILogger? logger = InstanceManager.Instance.GetExistingInstance<ILogger>();
                     if (logger != null && logger.IsEnabled(LogLevel.Error))
                     {
-                        logger.LogError(ex, $"[RT.{nameof(PacketHandlerCompiler<,>)}:Internal] failed-compile {x01}");
+                        logger.LogError(ex, "[RT.PacketHandlerCompiler:Internal] failed-compile {X01}", x01);
                     }
 
                     throw; // BUG-78: Fail-fast instead of continuing with incomplete handlers
@@ -388,8 +388,7 @@ internal sealed class PacketHandlerCompiler<[DynamicallyAccessedMembers(Dynamica
                 : throw new InternalErrorException(
                         $"Handler '{method.DeclaringType?.Name}.{method.Name}': " +
                         "when the first parameter is PacketContext<T>, " +
-                        "the only valid second parameter is CancellationToken. " +
-                        $"Found {parms.Length} parameter(s).");
+                        "the only valid second parameter is CancellationToken. Found {parms.Length} parameter(s).");
         }
 
         // ---- new-style: raw memory payload ----
@@ -415,8 +414,7 @@ internal sealed class PacketHandlerCompiler<[DynamicallyAccessedMembers(Dynamica
 
             throw new InternalErrorException(
                 $"Handler '{method.DeclaringType?.Name}.{method.Name}': " +
-                "raw memory signature only supports 2 or 3 parameters " +
-                $"(ReadOnlyMemory<byte>, IConnection[, CancellationToken]). Found {parms.Length}.");
+                "raw memory signature only supports 2 or 3 parameters (ReadOnlyMemory<byte>, IConnection[, CancellationToken]). Found {parms.Length}.");
         }
 
         // ---- legacy-style: first param must implement IPacket ----
@@ -453,8 +451,7 @@ internal sealed class PacketHandlerCompiler<[DynamicallyAccessedMembers(Dynamica
 
             throw new InternalErrorException(
                 $"Handler '{method.DeclaringType?.Name}.{method.Name}': " +
-                "legacy signature only supports 2 or 3 parameters " +
-                $"(TPacket, IConnection[, CancellationToken]). Found {parms.Length}.");
+                "legacy signature only supports 2 or 3 parameters (TPacket, IConnection[, CancellationToken]). Found {parms.Length}.");
         }
 
         throw new InternalErrorException(

--- a/src/Nalix.Runtime/Middleware/Standard/PermissionMiddleware.cs
+++ b/src/Nalix.Runtime/Middleware/Standard/PermissionMiddleware.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -55,9 +55,8 @@ public class PermissionMiddleware : IPacketMiddleware<IPacket>
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
         {
-            _logger.LogTrace(
-                $"[RT.{nameof(PermissionMiddleware)}] deny op=0x{context.Attributes.PacketOpcode.OpCode:X4} " +
-                $"need={context.Attributes.Permission?.Level.ToString() ?? "N/A (no attribute)"} have={context.Connection.Level}");
+            string needLevel = context.Attributes.Permission?.Level.ToString() ?? "N/A (no attribute)";
+            _logger.LogTrace("[RT.PermissionMiddleware] deny op=0x{OpCode:X4} need={NeedLevel} have={HaveLevel}", context.Attributes.PacketOpcode.OpCode, needLevel, context.Connection.Level);
         }
 
         if (!DirectiveGuard.TryAcquire(

--- a/src/Nalix.Runtime/Middleware/Standard/RateLimitMiddleware.cs
+++ b/src/Nalix.Runtime/Middleware/Standard/RateLimitMiddleware.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -81,7 +81,7 @@ public class RateLimitMiddleware : IPacketMiddleware<IPacket>
             // If the limiter has been disposed (e.g., during shutdown), deny the packet (fail-closed)
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning($"[RT.{nameof(RateLimitMiddleware)}:Invoke] rate-limiter-disposed request-denied");
+                _logger.LogWarning("[RT.RateLimitMiddleware:Invoke] rate-limiter-disposed request-denied");
             }
             return;
         }

--- a/src/Nalix.Runtime/Throttling/ConcurrencyGate.Cleanup.cs
+++ b/src/Nalix.Runtime/Throttling/ConcurrencyGate.Cleanup.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -44,7 +44,7 @@ public sealed partial class ConcurrencyGate
 
                 if (_logger != null && _logger.IsEnabled(LogLevel.Information))
                 {
-                    _logger.LogInformation($"[RT.{nameof(ConcurrencyGate)}] circuit breaker closed");
+                    _logger.LogInformation("[RT.ConcurrencyGate] circuit breaker closed");
                 }
             }
 
@@ -71,9 +71,7 @@ public sealed partial class ConcurrencyGate
 
                 if (_logger != null && _logger.IsEnabled(LogLevel.Error))
                 {
-                    _logger.LogError(
-                        $"[RT.{nameof(ConcurrencyGate)}] circuit breaker opened " +
-                        $"(rejection_rate={rejectionRate:P2}, attempts={totalAttempts})");
+                    _logger.LogError("[RT.ConcurrencyGate] circuit breaker opened (rejection_rate={RejectionRate}, attempts={TotalAttempts})", rejectionRate, totalAttempts);
                 }
             }
 
@@ -128,8 +126,7 @@ public sealed partial class ConcurrencyGate
         {
             _ = Interlocked.Increment(ref _totalRejected);
             throw new ConcurrencyFailureException(
-                $"Concurrency queue is full for opcode {opcode:X4} " +
-                $"(limit={entry.QueueMax}, current={entry.QueueCount})");
+                $"Concurrency queue is full for opcode {opcode:X4} (limit={entry.QueueMax}, current={entry.QueueCount})");
         }
 
         _ = Interlocked.Increment(ref _totalQueued);
@@ -202,7 +199,7 @@ public sealed partial class ConcurrencyGate
             {
                 if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug($"[RT.{nameof(ConcurrencyGate)}] cleanup removed={removed} remaining={_table.Count}");
+                    _logger.LogDebug("[RT.ConcurrencyGate] cleanup removed={Removed} remaining={TableCount}", removed, _table.Count);
                 }
             }
         }
@@ -210,7 +207,7 @@ public sealed partial class ConcurrencyGate
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[RT.{nameof(ConcurrencyGate)}] cleanup-error");
+                _logger.LogError(ex, "[RT.ConcurrencyGate] cleanup-error");
             }
         }
     }

--- a/src/Nalix.Runtime/Throttling/ConcurrencyGate.Report.cs
+++ b/src/Nalix.Runtime/Throttling/ConcurrencyGate.Report.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -173,14 +173,7 @@ public sealed partial class ConcurrencyGate
 
             _ = sb.AppendLine(
                 CultureInfo.InvariantCulture,
-                $"0x{opcode:X4} | " +
-                $"{entry.Capacity,8} | " +
-                $"{inUse,5} | " +
-                $"{available,5} | " +
-                $"{queueCount,5} | " +
-                $"{queueMaxStr,8} | " +
-                $"{queueEnabled,7} | " +
-                $"{lastUsed:HH:mm:ss}");
+                $"0x{opcode:X4} | {entry.Capacity,8} | {inUse,5} | {available,5} | {queueCount,5} | {queueMaxStr,8} | {queueEnabled,7} | {lastUsed:HH:mm:ss}");
         }
     }
 

--- a/src/Nalix.Runtime/Throttling/ConcurrencyGate.Types.cs
+++ b/src/Nalix.Runtime/Throttling/ConcurrencyGate.Types.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -151,7 +151,7 @@ public sealed partial class ConcurrencyGate
                 _ = Interlocked.Decrement(ref _activeUsers);
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
                 {
-                    this.Logger.LogError($"[RT.{nameof(ConcurrencyGate)}:Entry] activeUsers overflow detected");
+                    this.Logger.LogError("[RT.ConcurrencyGate:Entry] activeUsers overflow detected");
                 }
                 return false;
             }
@@ -171,7 +171,7 @@ public sealed partial class ConcurrencyGate
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
                 {
-                    this.Logger.LogError($"[RT.{nameof(ConcurrencyGate)}:Entry] activeUsers underflow detected");
+                    this.Logger.LogError("[RT.ConcurrencyGate:Entry] activeUsers underflow detected");
                 }
                 _ = Interlocked.Exchange(ref _activeUsers, 0);
             }
@@ -216,7 +216,7 @@ public sealed partial class ConcurrencyGate
             {
                 if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
                 {
-                    this.Logger.LogError($"[RT.{nameof(ConcurrencyGate)}:Entry] queueCount underflow detected");
+                    this.Logger.LogError("[RT.ConcurrencyGate:Entry] queueCount underflow detected");
                 }
                 _ = Interlocked.Exchange(ref _queueCount, 0);
             }
@@ -253,8 +253,7 @@ public sealed partial class ConcurrencyGate
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Warning))
                     {
-                        this.Logger.LogWarning(
-                            $"[RT.{nameof(ConcurrencyGate)}:Entry] disposing with {remainingUsers} active users");
+                        this.Logger.LogWarning("[RT.ConcurrencyGate:Entry] disposing with {ActiveUsers} active users", remainingUsers);
                     }
                 }
 
@@ -271,7 +270,7 @@ public sealed partial class ConcurrencyGate
                 {
                     if (this.Logger != null && this.Logger.IsEnabled(LogLevel.Error))
                     {
-                        this.Logger.LogError(ex, $"[RT.{nameof(ConcurrencyGate)}:Entry] disposal-error");
+                        this.Logger.LogError(ex, "[RT.ConcurrencyGate:Entry] disposal-error");
                     }
                 }
             }
@@ -316,7 +315,7 @@ public sealed partial class ConcurrencyGate
             {
                 if (_entry.Logger != null && _entry.Logger.IsEnabled(LogLevel.Error))
                 {
-                    _entry.Logger.LogError(ex, $"[RT.{nameof(ConcurrencyGate)}:Lease] release-error");
+                    _entry.Logger.LogError(ex, "[RT.ConcurrencyGate:Lease] release-error");
                 }
             }
             finally

--- a/src/Nalix.Runtime/Throttling/ConcurrencyGate.cs
+++ b/src/Nalix.Runtime/Throttling/ConcurrencyGate.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -158,7 +158,7 @@ public sealed partial class ConcurrencyGate : IReportable, IWithLogging<Concurre
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[RT.{nameof(ConcurrencyGate)}:{nameof(TryEnter)}] unexpected error opcode={opcode:X4}");
+                _logger.LogError(ex, "[RT.ConcurrencyGate:TryEnter] unexpected error opcode={OpCode}", opcode);
             }
             lease = default;
             return false;

--- a/src/Nalix.Runtime/Throttling/PolicyRateLimiter.cs
+++ b/src/Nalix.Runtime/Throttling/PolicyRateLimiter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -194,7 +194,7 @@ public sealed class PolicyRateLimiter : IReportable, IDisposable, IWithLogging<P
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning($"[RT.{nameof(PolicyRateLimiter)}] invalid-burst burst={rl.Burst}");
+                _logger.LogWarning("[RT.PolicyRateLimiter] invalid-burst burst={RlBurst}", rl.Burst);
             }
             return CREATE_DENIED_DECISION(isHard: true);
         }
@@ -250,7 +250,7 @@ public sealed class PolicyRateLimiter : IReportable, IDisposable, IWithLogging<P
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Information))
         {
-            _logger.LogInformation($"[RT.{nameof(PolicyRateLimiter)}:{nameof(Dispose)}] disposed");
+            _logger.LogInformation("[RT.PolicyRateLimiter:Dispose] disposed");
         }
 
         GC.SuppressFinalize(this);
@@ -309,7 +309,7 @@ public sealed class PolicyRateLimiter : IReportable, IDisposable, IWithLogging<P
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning($"[RT.{nameof(PolicyRateLimiter)}] missing-endpoint opCode={context.Packet.Header.OpCode}");
+                _logger.LogWarning("[RT.PolicyRateLimiter] missing-endpoint opCode={OpCode}", context.Packet.Header.OpCode);
             }
 
             return CREATE_DENIED_DECISION(isHard: false);

--- a/src/Nalix.Runtime/Throttling/TokenBucketLimiter.Cleanup.cs
+++ b/src/Nalix.Runtime/Throttling/TokenBucketLimiter.Cleanup.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -45,8 +45,7 @@ public sealed partial class TokenBucketLimiter
             {
                 if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug($"[RT.{nameof(TokenBucketLimiter)}:Internal] " +
-                                  $"Cleanup removed={removed}");
+                    _logger.LogDebug("[RT.TokenBucketLimiter:Internal] Cleanup removed={Removed}", removed);
                 }
             }
         }
@@ -54,14 +53,14 @@ public sealed partial class TokenBucketLimiter
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning($"[RT.{nameof(TokenBucketLimiter)}:Internal] Cleanup was cancelled due to timeout");
+                _logger.LogWarning("[RT.TokenBucketLimiter:Internal] Cleanup was cancelled due to timeout");
             }
         }
         catch (Exception ex) when (ex is not ObjectDisposedException)
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Error))
             {
-                _logger.LogError(ex, $"[RT.{nameof(TokenBucketLimiter)}:Internal] cleanup-error");
+                _logger.LogError(ex, "[RT.TokenBucketLimiter:Internal] cleanup-error");
             }
         }
     }
@@ -184,8 +183,7 @@ public sealed partial class TokenBucketLimiter
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning($"[RT.{nameof(TokenBucketLimiter)}:Internal] " +
-                            $"Evicted {removed} endpoints to enforce MaxTrackedEndpoints limit");
+                _logger.LogWarning("[RT.TokenBucketLimiter:Internal] Evicted {Removed} endpoints to enforce MaxTrackedEndpoints limit", removed);
             }
         }
 

--- a/src/Nalix.Runtime/Throttling/TokenBucketLimiter.cs
+++ b/src/Nalix.Runtime/Throttling/TokenBucketLimiter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -234,7 +234,7 @@ public sealed partial class TokenBucketLimiter : IDisposable, IAsyncDisposable, 
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning($"[RT.{nameof(TokenBucketLimiter)}:Internal] endpoint-limit-reached-precheck count={_totalEndpointCount} limit={_options.MaxTrackedEndpoints}");
+                _logger.LogWarning("[RT.TokenBucketLimiter:Internal] endpoint-limit-reached-precheck count={TotalEndpoints} limit={MaxEndpoints}", _totalEndpointCount, _options.MaxTrackedEndpoints);
             }
 
             return new EndpointStateResult
@@ -270,7 +270,7 @@ public sealed partial class TokenBucketLimiter : IDisposable, IAsyncDisposable, 
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug($"[RT.{nameof(TokenBucketLimiter)}:Internal] new-endpoint total={_totalEndpointCount}");
+            _logger.LogDebug("[RT.TokenBucketLimiter:Internal] new-endpoint total={TotalEndpoints}", _totalEndpointCount);
         }
 
         return new EndpointStateResult { State = newState, IsNew = true };
@@ -282,7 +282,7 @@ public sealed partial class TokenBucketLimiter : IDisposable, IAsyncDisposable, 
         {
             if (_logger != null && _logger.IsEnabled(LogLevel.Warning))
             {
-                _logger.LogWarning($"[RT.{nameof(TokenBucketLimiter)}:Internal] endpoint-limit-reached-precheck count={_totalEndpointCount} limit={_options.MaxTrackedEndpoints}");
+                _logger.LogWarning("[RT.TokenBucketLimiter:Internal] endpoint-limit-reached-precheck count={TotalEndpoints} limit={MaxEndpoints}", _totalEndpointCount, _options.MaxTrackedEndpoints);
             }
             return new EndpointStateResult { EarlyDecision = this.CREATE_LIMIT_REACHED_DECISION() };
         }
@@ -304,7 +304,7 @@ public sealed partial class TokenBucketLimiter : IDisposable, IAsyncDisposable, 
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug($"[RT.{nameof(TokenBucketLimiter)}:Internal] new-endpoint total={_totalEndpointCount}");
+            _logger.LogDebug("[RT.TokenBucketLimiter:Internal] new-endpoint total={TotalEndpoints}", _totalEndpointCount);
         }
 
         return new EndpointStateResult { State = newState, IsNew = true };
@@ -461,7 +461,7 @@ public sealed partial class TokenBucketLimiter : IDisposable, IAsyncDisposable, 
             int retryMs = this.CALCULATE_DELAY_MS(now, state.HardBlockedUntilSw);
             if (_logger != null && _logger.IsEnabled(LogLevel.Trace))
             {
-                _logger.LogTrace($"[RT.{nameof(TokenBucketLimiter)}:Internal] hard-blocked retry_ms={retryMs}");
+                _logger.LogTrace("[RT.TokenBucketLimiter:Internal] hard-blocked retry_ms={RetryMs}", retryMs);
             }
 
             decision = new RateLimitDecision
@@ -514,7 +514,7 @@ public sealed partial class TokenBucketLimiter : IDisposable, IAsyncDisposable, 
 
         if (credit <= 1 && _logger != null && _logger.IsEnabled(LogLevel.Trace))
         {
-            _logger.LogTrace($"[RT.{nameof(TokenBucketLimiter)}:Internal] allow credit={credit}");
+            _logger.LogTrace("[RT.TokenBucketLimiter:Internal] allow credit={Credit}", credit);
         }
 
         return new RateLimitDecision
@@ -938,7 +938,7 @@ public sealed partial class TokenBucketLimiter : IDisposable, IAsyncDisposable, 
 
         if (_logger != null && _logger.IsEnabled(LogLevel.Debug))
         {
-            _logger.LogDebug($"[RT.{nameof(TokenBucketLimiter)}:{nameof(Dispose)}] disposed");
+            _logger.LogDebug("[RT.TokenBucketLimiter:Dispose] disposed");
         }
     }
 

--- a/src/Nalix.Runtime/Timekeeping/TimeSynchronizer.cs
+++ b/src/Nalix.Runtime/Timekeeping/TimeSynchronizer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -133,7 +133,7 @@ public sealed class TimeSynchronizer : IDisposable, IActivatable
     {
         if (s_logger != null && s_logger.IsEnabled(LogLevel.Debug))
         {
-            s_logger.LogDebug($"[RT.{nameof(TimeSynchronizer)}] initialized");
+            s_logger.LogDebug("[RT.TimeSynchronizer] initialized");
         }
     }
 
@@ -205,7 +205,7 @@ public sealed class TimeSynchronizer : IDisposable, IActivatable
                 {
                     if (s_logger != null && s_logger.IsEnabled(LogLevel.Warning))
                     {
-                        s_logger.LogWarning($"[RT.{nameof(TimeSynchronizer)}] restart-timeout waiting for previous loop to stop");
+                        s_logger.LogWarning("[RT.TimeSynchronizer] restart-timeout waiting for previous loop to stop");
                     }
                 }
             }
@@ -255,7 +255,7 @@ public sealed class TimeSynchronizer : IDisposable, IActivatable
                     {
                         if (s_logger != null && s_logger.IsEnabled(LogLevel.Warning))
                         {
-                            s_logger.LogWarning($"[RT.{nameof(TimeSynchronizer)}] dispose-timeout waiting for loop shutdown");
+                            s_logger.LogWarning("[RT.TimeSynchronizer] dispose-timeout waiting for loop shutdown");
                         }
                     }
                 }
@@ -270,7 +270,7 @@ public sealed class TimeSynchronizer : IDisposable, IActivatable
 
         if (s_logger != null && s_logger.IsEnabled(LogLevel.Debug))
         {
-            s_logger.LogDebug($"[RT.{nameof(TimeSynchronizer)}] disposed");
+            s_logger.LogDebug("[RT.TimeSynchronizer] disposed");
         }
     }
 
@@ -312,7 +312,7 @@ public sealed class TimeSynchronizer : IDisposable, IActivatable
 
                     if (s_logger != null && s_logger.IsEnabled(LogLevel.Information))
                     {
-                        s_logger.LogInformation($"[RT.{nameof(TimeSynchronizer)}] started period={this.Period.TotalMilliseconds:0.#}ms");
+                        s_logger.LogInformation("[RT.TimeSynchronizer] started period={PeriodTotalMilliseconds}ms", this.Period.TotalMilliseconds);
                     }
 
                     while (!ct.IsCancellationRequested)
@@ -345,7 +345,7 @@ public sealed class TimeSynchronizer : IDisposable, IActivatable
                                     {
                                         if (s_logger != null && s_logger.IsEnabled(LogLevel.Error))
                                         {
-                                            s_logger.LogError(ex, $"[RT.{nameof(TimeSynchronizer)}] handler-error");
+                                            s_logger.LogError(ex, "[RT.TimeSynchronizer] handler-error");
                                         }
                                     }
                                 }, (handler, timestamp), preferLocal: false);
@@ -360,7 +360,7 @@ public sealed class TimeSynchronizer : IDisposable, IActivatable
                                 {
                                     if (s_logger != null && s_logger.IsEnabled(LogLevel.Error))
                                     {
-                                        s_logger.LogError(ex, $"[RT.{nameof(TimeSynchronizer)}] handler-error");
+                                        s_logger.LogError(ex, "[RT.TimeSynchronizer] handler-error");
                                     }
                                 }
                             }
@@ -371,9 +371,7 @@ public sealed class TimeSynchronizer : IDisposable, IActivatable
                             long elapsed = Clock.UnixMillisecondsNow() - timestamp;
                             if (elapsed > this.Period.TotalMilliseconds * 1.5)
                             {
-                                s_logger.LogWarning(
-                                    $"[RT.{nameof(TimeSynchronizer)}] tick overrun " +
-                                    $"elapsed={elapsed}ms period={this.Period.TotalMilliseconds:0.#}ms");
+                                s_logger.LogWarning("[RT.TimeSynchronizer] tick overrun elapsed={ElapsedMs}ms period={PeriodTotalMilliseconds}ms", elapsed, this.Period.TotalMilliseconds);
                             }
                         }
 
@@ -388,7 +386,7 @@ public sealed class TimeSynchronizer : IDisposable, IActivatable
                 {
                     if (s_logger != null && s_logger.IsEnabled(LogLevel.Error))
                     {
-                        s_logger.LogError(ex, $"[RT.{nameof(TimeSynchronizer)}] loop-error");
+                        s_logger.LogError(ex, "[RT.TimeSynchronizer] loop-error");
                     }
                 }
                 finally
@@ -397,7 +395,7 @@ public sealed class TimeSynchronizer : IDisposable, IActivatable
                     _stoppedSignal.Set();
                     if (s_logger != null && s_logger.IsEnabled(LogLevel.Information))
                     {
-                        s_logger.LogInformation($"[RT.{nameof(TimeSynchronizer)}] stopped");
+                        s_logger.LogInformation("[RT.TimeSynchronizer] stopped");
                     }
                 }
             },

--- a/src/Nalix.SDK/Transport/Internal/Udp/UdpFrameSender.cs
+++ b/src/Nalix.SDK/Transport/Internal/Udp/UdpFrameSender.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+﻿// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -65,8 +65,7 @@ internal sealed class UdpFrameSender : IDisposable
             if (current.Length + ISnowflake.Size > _options.MaxUdpDatagramSize)
             {
                 throw new NetworkException(
-                    $"UDP datagram too large after transformation: {current.Length + ISnowflake.Size} bytes. " +
-                    $"Max = {_options.MaxUdpDatagramSize}");
+                    $"UDP datagram too large after transformation: {current.Length + ISnowflake.Size} bytes. Max = {_options.MaxUdpDatagramSize}");
             }
 
             // Envelope: [SessionToken (8 bytes) | Transformed Payload]


### PR DESCRIPTION
- Replace all $"..." log calls with structured template + parameters
- Hardcode nameof() references in log prefixes (e.g. [NW.Connection:Dispose])
- Pass exception as first param per Rule 2 (ex.Message removed from templates)
- Extract ternary/conditional expressions to variables before logging
- Pre-compute format specifiers (HH:mm:ss, :F0, :0.#) before passing as params
- Merge multi-line $"" + $"" concatenations into single templates
- Extract GetType().Name calls to local variables where in non-catch scope

Scope: 67 files, +421/-727 lines
Build: 0 errors, 2 warnings