### PR TITLE
fix(ci): improve test reliability and CI diagnostics

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -97,26 +97,28 @@ jobs:
         shell: bash
         timeout-minutes: 20
         run: |
-          max_retries=3
+          max_retries=1
           attempt=1
           while true; do
             # Clean results directory to avoid mixing failed and successful runs
             rm -rf "$TEST_RESULTS_DIR"/* 2>/dev/null || true
-            
+
             echo "Running tests (Attempt $attempt/$max_retries)..."
             if dotnet test "${{ inputs.test }}" --configuration Release --no-build --no-restore \
               --logger "trx" --results-directory "$TEST_RESULTS_DIR" \
-              --collect:"XPlat Code Coverage" -m; then
+              --collect:"XPlat Code Coverage" \
+              --blame-hang --blame-crash --blame-hang-timeout 300000 \
+              -m; then
               echo "Tests passed!"
               break
             fi
-            
+
             exit_code=$?
             if [ $attempt -ge $max_retries ]; then
               echo "Tests failed after $max_retries attempts."
               exit $exit_code
             fi
-            
+
             echo "Test run failed (exit code $exit_code). Retrying in 10 seconds..."
             attempt=$((attempt+1))
             sleep 10

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  checks: write
+  pull-requests: write
 
 jobs:
   build-and-upload:

--- a/tests/Nalix.Framework.Tests/Memory/MemoryConfigAndLeaseTests.cs
+++ b/tests/Nalix.Framework.Tests/Memory/MemoryConfigAndLeaseTests.cs
@@ -184,10 +184,20 @@ public sealed partial class MemoryTests
     [Fact]
     public void TestBufferLeaseRent()
     {
+        // Rent through the manager directly instead of mutating the process-wide
+        // ByteArrayPool delegates.  The original code called
+        // BufferLease.ByteArrayPool.Configure(manager) which left a disposed
+        // delegate target in the global static field after this method returned.
         using var manager = new BufferPoolManager();
-        BufferLease.ByteArrayPool.Configure(manager);
-        byte[] arr = BufferLease.ByteArrayPool.Rent(2114);
-        Assert.True(arr.Length >= 2114, $"Expected >= 2114, got {arr.Length}");
+        byte[] arr = manager.Rent(2114);
+        try
+        {
+            Assert.True(arr.Length >= 2114, $"Expected >= 2114, got {arr.Length}");
+        }
+        finally
+        {
+            manager.Return(arr);
+        }
     }
 
 

--- a/tests/Nalix.Framework.Tests/TestAssemblySetup.cs
+++ b/tests/Nalix.Framework.Tests/TestAssemblySetup.cs
@@ -2,6 +2,9 @@ using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using Nalix.Environment.IO;
+using Xunit;
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, MaxParallelThreads = 1)]
 
 namespace Nalix.Framework.Tests;
 


### PR DESCRIPTION
- Reduce test max_retries to 1; add --blame-hang --blame-crash flags to dotnet test for crash/hang diagnostics in CI.
- Tighten release-extensions.yml permissions: read contents, write checks and pull-requests only.
- Fix TestBufferLeaseRent to use manager.Rent/Return directly instead of mutating global BufferLease.ByteArrayPool delegate, preventing disposed-delegate corruption across test runs.
- Force sequential test execution in Framework.Tests with MaxParallelThreads = 1 to eliminate cross-test interference.