### PR TITLE
refactor: WebSocket receive loop to avoid deadlocks

### DIFF
--- a/src/Nalix.SDK/Transport/WebSocketSession.cs
+++ b/src/Nalix.SDK/Transport/WebSocketSession.cs
@@ -131,8 +131,11 @@ public class WebSocketSession : TransportSession
 
             _loopCts = new CancellationTokenSource();
 
-            _ = Task.Factory.StartNew(() => _reader.ReceiveLoopAsync(_loopCts.Token),
-                _loopCts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
+            // Use fire-and-forget async instead of LongRunning thread —
+            // LongRunning + TaskScheduler.Default deadlocks in single-threaded
+            // runtimes (Blazor WASM). The async loop yields correctly via
+            // ConfigureAwait(false) on both desktop and WASM.
+            _ = _reader.ReceiveLoopAsync(_loopCts.Token);
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {


### PR DESCRIPTION
Switch receive loop startup to fire-and-forget async call. Removes use of Task.Factory.StartNew with LongRunning, which could deadlock in single-threaded runtimes (e.g., Blazor WASM). Adds comments explaining the rationale for this change.
