### PR TITLE
fix(codec): nullable packet schema sizing

### DIFF
--- a/analyzers/Nalix.Analyzers.Generators/PacketSchemaGenerator.cs
+++ b/analyzers/Nalix.Analyzers.Generators/PacketSchemaGenerator.cs
@@ -288,7 +288,7 @@ public sealed class PacketSchemaGenerator : IIncrementalGenerator
                 {
                     string sizeExpr = BUILD_SIZE_EXPRESSION(memberType, $"this.{memberName}");
                     _ = sb.AppendLine($"            size += {sizeExpr};");
-                    staticSize += 4; // minimum: length prefix for dynamic fields
+                    staticSize += GET_MIN_SIZE(memberType);
                 }
             }
 
@@ -566,6 +566,38 @@ public sealed class PacketSchemaGenerator : IIncrementalGenerator
         }
 
         return "0";
+    }
+
+    private static int GET_MIN_SIZE(ITypeSymbol type)
+    {
+        int fixedSize = GET_FIXED_SIZE(type);
+        if (fixedSize > 0)
+        {
+            return fixedSize;
+        }
+
+        if (type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T })
+        {
+            return 1;
+        }
+
+        if (type is INamedTypeSymbol named && IMPLEMENTSI_PACKET(named))
+        {
+            return 0;
+        }
+
+        if (type.IsTupleType && type is INamedTypeSymbol tuple)
+        {
+            int size = 0;
+            for (int i = 0; i < tuple.TupleElements.Length; i++)
+            {
+                size += GET_MIN_SIZE(tuple.TupleElements[i].Type);
+            }
+
+            return size;
+        }
+
+        return 4;
     }
 
     private static string BUILD_ARRAY_SIZE_EXPRESSION(IArrayTypeSymbol arrayType, string accessor)

--- a/tests/Nalix.Codec.Tests/DataFrames/PacketNullableValueTypeTests.cs
+++ b/tests/Nalix.Codec.Tests/DataFrames/PacketNullableValueTypeTests.cs
@@ -1,0 +1,132 @@
+// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Nalix.Abstractions.Networking.Packets;
+using Nalix.Abstractions.Primitives;
+using Nalix.Abstractions.Serialization;
+using Nalix.Codec.DataFrames;
+
+namespace Nalix.Codec.Tests.DataFrames;
+
+public sealed partial class PacketNullableValueTypeTests
+{
+    public PacketNullableValueTypeTests()
+    {
+        if (!PacketRegistry.IsBuilt)
+        {
+            PacketRegistry.Build();
+        }
+    }
+
+    [Fact]
+    public void NullablePacketWithTerminalNullFieldsRoundTrips()
+    {
+        NullableValuePacket packet = new()
+        {
+            IsEndOfStream = true,
+            Capacity = null,
+            Duration = null
+        };
+
+        NullableValuePacket result = RoundTrip(packet);
+
+        Assert.True(result.IsEndOfStream);
+        Assert.Null(result.Capacity);
+        Assert.Null(result.Duration);
+    }
+
+    [Fact]
+    public void NullablePacketWithPopulatedFieldsRoundTrips()
+    {
+        NullableValuePacket packet = new()
+        {
+            IsEndOfStream = false,
+            Capacity = 128,
+            Duration = TimeSpan.FromSeconds(5)
+        };
+
+        NullableValuePacket result = RoundTrip(packet);
+
+        Assert.False(result.IsEndOfStream);
+        Assert.Equal(128, result.Capacity);
+        Assert.Equal(TimeSpan.FromSeconds(5), result.Duration);
+    }
+
+    [Fact]
+    public void NullablePacketWithMixedNullAndPopulatedFieldsRoundTrips()
+    {
+        NullableValuePacket packet = new()
+        {
+            IsEndOfStream = true,
+            Capacity = null,
+            Duration = TimeSpan.FromMinutes(2)
+        };
+
+        NullableValuePacket result = RoundTrip(packet);
+
+        Assert.True(result.IsEndOfStream);
+        Assert.Null(result.Capacity);
+        Assert.Equal(TimeSpan.FromMinutes(2), result.Duration);
+    }
+
+    [Fact]
+    public void TuplePacketWithNullableNullElementsRoundTrips()
+    {
+        TupleNullableValuePacket packet = new()
+        {
+            OptionalPair = (null, null)
+        };
+        packet.Header = packet.Header with { SequenceId = 88 };
+
+        byte[] bytes = packet.Serialize();
+        IPacket deserialized = PacketRegistry.Deserialize(bytes);
+        TupleNullableValuePacket result = Assert.IsType<TupleNullableValuePacket>(deserialized);
+
+        Assert.Equal(TupleNullableValuePacket.StaticOpCode, result.Header.OpCode);
+        Assert.Equal(packet.Header.SequenceId, result.Header.SequenceId);
+        Assert.Null(result.OptionalPair.Capacity);
+        Assert.Null(result.OptionalPair.Duration);
+    }
+
+    private static NullableValuePacket RoundTrip(NullableValuePacket packet)
+    {
+        packet.Header = packet.Header with { SequenceId = 77 };
+
+        byte[] bytes = packet.Serialize();
+        IPacket deserialized = PacketRegistry.Deserialize(bytes);
+        NullableValuePacket result = Assert.IsType<NullableValuePacket>(deserialized);
+
+        Assert.Equal(NullableValuePacket.StaticOpCode, result.Header.OpCode);
+        Assert.Equal(packet.Header.SequenceId, result.Header.SequenceId);
+
+        return result;
+    }
+
+    [Packet]
+    [GenerateFormatter]
+    [SerializePackable(SerializeLayout.Explicit)]
+    public sealed partial class NullableValuePacket : PacketBase<NullableValuePacket>, IPacketStaticOpcode
+    {
+        public static ushort StaticOpCode => 0x7A88;
+
+        [SerializeOrder(0)]
+        public bool IsEndOfStream { get; set; }
+
+        [SerializeOrder(1)]
+        public int? Capacity { get; set; }
+
+        [SerializeOrder(2)]
+        public TimeSpan? Duration { get; set; }
+    }
+
+    [Packet]
+    [GenerateFormatter]
+    [SerializePackable(SerializeLayout.Explicit)]
+    public sealed partial class TupleNullableValuePacket : PacketBase<TupleNullableValuePacket>, IPacketStaticOpcode
+    {
+        public static ushort StaticOpCode => 0x7A8B;
+
+        [SerializeOrder(0)]
+        public (int? Capacity, TimeSpan? Duration) OptionalPair { get; set; }
+    }
+}

--- a/tests/Nalix.Codec.Tests/Serialization/NullableValueFormatterTests.cs
+++ b/tests/Nalix.Codec.Tests/Serialization/NullableValueFormatterTests.cs
@@ -1,0 +1,101 @@
+// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Nalix.Abstractions.Exceptions;
+using Nalix.Codec.Serialization;
+using Nalix.Environment.Memory;
+
+namespace Nalix.Codec.Tests.Serialization;
+
+public sealed class NullableValueFormatterTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData(42)]
+    public void NullableIntRoundTrips(int? value) => RoundTrip(value);
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void NullableBoolRoundTrips(bool? value) => RoundTrip(value);
+
+    [Fact]
+    public void NullableTimeSpanRoundTripsNull()
+    {
+        TimeSpan? value = null;
+
+        RoundTrip(value);
+    }
+
+    [Fact]
+    public void NullableTimeSpanRoundTripsValue()
+    {
+        TimeSpan? value = TimeSpan.FromMilliseconds(12345);
+
+        RoundTrip(value);
+    }
+
+    [Fact]
+    public void NullableGuidRoundTripsNull()
+    {
+        Guid? value = null;
+
+        RoundTrip(value);
+    }
+
+    [Fact]
+    public void NullableGuidRoundTripsValue()
+    {
+        Guid? value = Guid.Parse("d3a2f52c-8f6b-4f4e-9b30-5d2b2d87a72d");
+
+        RoundTrip(value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(NullableTestStatus.Active)]
+    [InlineData(NullableTestStatus.Archived)]
+    public void NullableEnumRoundTrips(NullableTestStatus? value) => RoundTrip(value);
+
+    [Fact]
+    public void DeserializeWhenNullablePresenceFlagIsInvalidThrowsSerializationFailureException()
+    {
+        byte[] corrupt = [2];
+        IFormatter<int?> formatter = FormatterProvider.Get<int?>();
+
+        _ = Assert.Throws<SerializationFailureException>(() => DeserializeNullable(formatter, corrupt));
+    }
+
+    [Fact]
+    public void FormatterProviderResolvesNullableValueTypesWithoutManualRegistration()
+    {
+        IFormatter<int?> intFormatter = FormatterProvider.Get<int?>();
+        IFormatter<TimeSpan?> timeSpanFormatter = FormatterProvider.Get<TimeSpan?>();
+
+        Assert.NotNull(intFormatter);
+        Assert.NotNull(timeSpanFormatter);
+    }
+
+    private static void RoundTrip<T>(T? value) where T : struct
+    {
+        byte[] bytes = LiteSerializer.Serialize(value);
+        T? result = LiteSerializer.Deserialize<T?>(bytes, out int bytesRead);
+
+        Assert.Equal(bytes.Length, bytesRead);
+        Assert.Equal(value, result);
+    }
+
+    private static int? DeserializeNullable(IFormatter<int?> formatter, byte[] bytes)
+    {
+        DataReader reader = new(bytes);
+        return formatter.Deserialize(ref reader);
+    }
+
+    public enum NullableTestStatus : byte
+    {
+        None = 0,
+        Active = 1,
+        Archived = 2
+    }
+}

--- a/tests/Nalix.SDK.Tests/NullablePacketStreamTests.cs
+++ b/tests/Nalix.SDK.Tests/NullablePacketStreamTests.cs
@@ -1,0 +1,192 @@
+// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Diagnostics.CodeAnalysis;
+using Nalix.Abstractions;
+using Nalix.Abstractions.Networking.Packets;
+using Nalix.Abstractions.Primitives;
+using Nalix.Abstractions.Serialization;
+using Nalix.Codec.DataFrames;
+using Nalix.Environment.Memory;
+using Nalix.SDK.Options;
+using Nalix.SDK.Transport;
+using Nalix.SDK.Transport.Extensions;
+
+namespace Nalix.SDK.Tests;
+
+[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "xUnit tests intentionally follow the test synchronization context.")]
+public sealed partial class NullablePacketStreamTests
+{
+    public NullablePacketStreamTests()
+    {
+        if (!PacketRegistry.IsBuilt)
+        {
+            PacketRegistry.Build();
+        }
+    }
+
+    [Fact]
+    public async Task StreamAsyncWhenTerminalNullableFieldIsNullYieldsItemAndCompletes()
+    {
+        NullableStreamRequest request = new();
+        request.Header = request.Header with { SequenceId = 1001 };
+
+        NullableStreamItem response = new()
+        {
+            IsEndOfStream = true,
+            Capacity = null,
+            Duration = TimeSpan.FromSeconds(1)
+        };
+        response.Header = response.Header with { SequenceId = request.Header.SequenceId };
+
+        NullableStreamItem result = await ReadSingleStreamItemAsync(request, response);
+
+        Assert.True(result.IsEndOfStream);
+        Assert.Null(result.Capacity);
+        Assert.Equal(TimeSpan.FromSeconds(1), result.Duration);
+    }
+
+    [Fact]
+    public async Task StreamAsyncWhenTerminalNullableFieldHasValueYieldsItemAndCompletes()
+    {
+        NullableStreamRequest request = new();
+        request.Header = request.Header with { SequenceId = 1002 };
+
+        NullableStreamItem response = new()
+        {
+            IsEndOfStream = true,
+            Capacity = 128,
+            Duration = null
+        };
+        response.Header = response.Header with { SequenceId = request.Header.SequenceId };
+
+        NullableStreamItem result = await ReadSingleStreamItemAsync(request, response);
+
+        Assert.True(result.IsEndOfStream);
+        Assert.Equal(128, result.Capacity);
+        Assert.Null(result.Duration);
+    }
+
+    private static async Task<NullableStreamItem> ReadSingleStreamItemAsync(NullableStreamRequest request, NullableStreamItem response)
+    {
+        FakeStreamSession session = new(response);
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(3));
+
+        Task<List<NullableStreamSnapshot>> readTask = ReadAllSnapshotsAsync(session, request, cts.Token);
+        Task completed = await Task.WhenAny(readTask, Task.Delay(TimeSpan.FromSeconds(3), cts.Token));
+
+        Assert.Same(readTask, completed);
+
+        List<NullableStreamSnapshot> snapshots = await readTask;
+        NullableStreamSnapshot snapshot = Assert.Single(snapshots);
+
+        Assert.Equal(response.Header.SequenceId, snapshot.SequenceId);
+
+        return new NullableStreamItem
+        {
+            Header = new PacketHeader { SequenceId = snapshot.SequenceId },
+            IsEndOfStream = snapshot.IsEndOfStream,
+            Capacity = snapshot.Capacity,
+            Duration = snapshot.Duration
+        };
+    }
+
+    private static async Task<List<NullableStreamSnapshot>> ReadAllSnapshotsAsync(
+        FakeStreamSession session,
+        NullableStreamRequest request,
+        CancellationToken cancellationToken)
+    {
+        List<NullableStreamSnapshot> snapshots = [];
+
+        await foreach (NullableStreamItem item in session.StreamAsync<NullableStreamItem>(request, ct: cancellationToken))
+        {
+            snapshots.Add(new NullableStreamSnapshot(
+                item.Header.SequenceId,
+                item.IsEndOfStream,
+                item.Capacity,
+                item.Duration));
+        }
+
+        return snapshots;
+    }
+
+    private sealed class FakeStreamSession(NullableStreamItem response) : TransportSession
+    {
+        public override TransportOptions Options { get; } = new();
+        public override bool IsConnected => true;
+
+        public override event EventHandler? OnConnected
+        {
+            add { }
+            remove { }
+        }
+
+        public override event EventHandler<Exception>? OnDisconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public override event EventHandler<IBufferLease>? OnMessageReceived;
+
+        public override event EventHandler<Exception>? OnError
+        {
+            add { }
+            remove { }
+        }
+
+        public override Task ConnectAsync(string? host = null, ushort? port = null, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public override Task DisconnectAsync() => Task.CompletedTask;
+
+        public override Task SendAsync(IPacket packet, CancellationToken ct = default)
+            => this.SendAsync(packet, encrypt: null, ct);
+
+        public override Task SendAsync(IPacket packet, bool? encrypt = null, CancellationToken ct = default)
+        {
+            byte[] data = response.Serialize();
+            using BufferLease lease = BufferLease.CopyFrom(data);
+            this.OnMessageReceived?.Invoke(this, lease);
+            return Task.CompletedTask;
+        }
+
+        public override Task SendAsync(ReadOnlyMemory<byte> payload, bool? encrypt = null, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public override void ResetSequenceCounters() { }
+
+        protected override void Dispose(bool disposing) { }
+    }
+
+    private readonly record struct NullableStreamSnapshot(
+        ushort SequenceId,
+        bool IsEndOfStream,
+        int? Capacity,
+        TimeSpan? Duration);
+
+    [Packet]
+    [GenerateFormatter]
+    [SerializePackable(SerializeLayout.Explicit)]
+    public sealed partial class NullableStreamRequest : PacketBase<NullableStreamRequest>, IPacketStaticOpcode
+    {
+        public static ushort StaticOpCode => 0x7A89;
+    }
+
+    [Packet]
+    [GenerateFormatter]
+    [SerializePackable(SerializeLayout.Explicit)]
+    public sealed partial class NullableStreamItem : PacketBase<NullableStreamItem>, IPacketStaticOpcode, IPacketStreamable
+    {
+        public static ushort StaticOpCode => 0x7A8A;
+
+        [SerializeOrder(0)]
+        public bool IsEndOfStream { get; set; }
+
+        [SerializeOrder(1)]
+        public int? Capacity { get; set; }
+
+        [SerializeOrder(2)]
+        public TimeSpan? Duration { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes nullable value-type packet deserialization by correcting generated packet minimum-size metadata for `Nullable<T>` and tuple-contained nullable fields. Closes #288 

---

## Root Cause

`PacketSchemaGenerator` treated every dynamic field as having a 4-byte minimum length prefix. `Nullable<T>` actually serializes as a 1-byte presence flag plus an optional payload, so valid packets with null nullable fields could be rejected before deserialization.