### PR TITLE
fix(generators): guard every incremental model

### DIFF
--- a/analyzers/Nalix.Analyzers.Generators/ConfigurationGenerator.cs
+++ b/analyzers/Nalix.Analyzers.Generators/ConfigurationGenerator.cs
@@ -43,20 +43,12 @@ public class ConfigurationGenerator : IIncrementalGenerator
 
         public bool Equals(ConfigPropertyModel other)
         {
-            if (this.Name != other.Name || this.IniMethod != other.IniMethod || this.Comment != other.Comment || this.IsString != other.IsString || this.IsEnum != other.IsEnum || this.ValidationSnippets.Length != other.ValidationSnippets.Length)
+            if (this.Name != other.Name || this.IniMethod != other.IniMethod || this.Comment != other.Comment || this.IsString != other.IsString || this.IsEnum != other.IsEnum)
             {
                 return false;
             }
 
-            for (int i = 0; i < this.ValidationSnippets.Length; i++)
-            {
-                if (this.ValidationSnippets[i] != other.ValidationSnippets[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return Internal.ModelEquality.SequenceEqual(this.ValidationSnippets, other.ValidationSnippets);
         }
         public override bool Equals(object obj) => obj is ConfigPropertyModel other && this.Equals(other);
         public override int GetHashCode()
@@ -69,9 +61,12 @@ public class ConfigurationGenerator : IIncrementalGenerator
                 hash = (hash * 23) + (this.Comment?.GetHashCode() ?? 0);
                 hash = (hash * 23) + this.IsString.GetHashCode();
                 hash = (hash * 23) + this.IsEnum.GetHashCode();
-                foreach (string s in this.ValidationSnippets)
+                if (!this.ValidationSnippets.IsDefaultOrEmpty)
                 {
-                    hash = (hash * 23) + (s?.GetHashCode() ?? 0);
+                    foreach (string s in this.ValidationSnippets)
+                    {
+                        hash = (hash * 23) + (s?.GetHashCode() ?? 0);
+                    }
                 }
 
                 return hash;
@@ -100,28 +95,13 @@ public class ConfigurationGenerator : IIncrementalGenerator
 
         public bool Equals(ConfigClassModel other)
         {
-            if (this.HintName != other.HintName || this.Namespace != other.Namespace || this.Name != other.Name || this.SectionComment != other.SectionComment || this.NestingOpeners.Length != other.NestingOpeners.Length || this.Properties.Length != other.Properties.Length)
+            if (this.HintName != other.HintName || this.Namespace != other.Namespace || this.Name != other.Name || this.SectionComment != other.SectionComment)
             {
                 return false;
             }
 
-            for (int i = 0; i < this.NestingOpeners.Length; i++)
-            {
-                if (this.NestingOpeners[i] != other.NestingOpeners[i])
-                {
-                    return false;
-                }
-            }
-
-            for (int i = 0; i < this.Properties.Length; i++)
-            {
-                if (!this.Properties[i].Equals(other.Properties[i]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return Internal.ModelEquality.SequenceEqual(this.NestingOpeners, other.NestingOpeners)
+                && Internal.ModelEquality.SequenceEqual(this.Properties, other.Properties);
         }
         public override bool Equals(object obj) => obj is ConfigClassModel other && this.Equals(other);
         public override int GetHashCode()
@@ -133,14 +113,20 @@ public class ConfigurationGenerator : IIncrementalGenerator
                 hash = (hash * 23) + (this.Namespace?.GetHashCode() ?? 0);
                 hash = (hash * 23) + (this.Name?.GetHashCode() ?? 0);
                 hash = (hash * 23) + (this.SectionComment?.GetHashCode() ?? 0);
-                foreach (string s in this.NestingOpeners)
+                if (!this.NestingOpeners.IsDefaultOrEmpty)
                 {
-                    hash = (hash * 23) + (s?.GetHashCode() ?? 0);
+                    foreach (string s in this.NestingOpeners)
+                    {
+                        hash = (hash * 23) + (s?.GetHashCode() ?? 0);
+                    }
                 }
 
-                foreach (ConfigPropertyModel p in this.Properties)
+                if (!this.Properties.IsDefaultOrEmpty)
                 {
-                    hash = (hash * 23) + p.GetHashCode();
+                    foreach (ConfigPropertyModel p in this.Properties)
+                    {
+                        hash = (hash * 23) + p.GetHashCode();
+                    }
                 }
 
                 return hash;

--- a/analyzers/Nalix.Analyzers.Generators/Internal/ModelEquality.cs
+++ b/analyzers/Nalix.Analyzers.Generators/Internal/ModelEquality.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Immutable;
+
+namespace Nalix.Analyzers.Generators.Internal;
+
+/// <summary>
+/// Null-safe structural comparison of <see cref="ImmutableArray{T}"/> for incremental-generator models.
+/// </summary>
+/// <remarks>
+/// A model produced by a <c>return default</c> path carries <c>default</c> (null-backed) arrays. The
+/// incremental driver compares consecutive model values via <c>Equals</c> in
+/// <c>NodeStateTable.Builder.GetModifiedItemAndState</c>; any access to <see cref="ImmutableArray{T}.Length"/>
+/// or <see cref="ImmutableArray{T}.SequenceEqual"/> on a <c>default</c> value dereferences the null backing
+/// array and throws <see cref="NullReferenceException"/>, which Roslyn surfaces as an IDE-wide crash. These
+/// helpers treat <c>default</c> and empty as equivalent so equality never touches the null backing array.
+/// </remarks>
+internal static class ModelEquality
+{
+    /// <summary>
+    /// Compares two arrays element-by-element using the default equality comparer,
+    /// treating <c>default</c> and empty as equal.
+    /// </summary>
+    public static bool SequenceEqual<T>(ImmutableArray<T> left, ImmutableArray<T> right)
+    {
+        if (left.IsDefaultOrEmpty && right.IsDefaultOrEmpty)
+        {
+            return true;
+        }
+
+        if (left.IsDefaultOrEmpty || right.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < left.Length; i++)
+        {
+            if (!System.Collections.Generic.EqualityComparer<T>.Default.Equals(left[i], right[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/analyzers/Nalix.Analyzers.Generators/PacketHandlerGenerator.cs
+++ b/analyzers/Nalix.Analyzers.Generators/PacketHandlerGenerator.cs
@@ -116,30 +116,13 @@ public sealed class PacketHandlerGenerator : IIncrementalGenerator
                 this.IsStatic != other.IsStatic ||
                 this.NamespaceName != other.NamespaceName ||
                 this.GeneratedNamespace != other.GeneratedNamespace ||
-                this.HasInjectedFields != other.HasInjectedFields ||
-                this.InjectedMembersAssignments.Length != other.InjectedMembersAssignments.Length ||
-                this.Methods.Length != other.Methods.Length)
+                this.HasInjectedFields != other.HasInjectedFields)
             {
                 return false;
             }
 
-            for (int i = 0; i < this.InjectedMembersAssignments.Length; i++)
-            {
-                if (this.InjectedMembersAssignments[i] != other.InjectedMembersAssignments[i])
-                {
-                    return false;
-                }
-            }
-
-            for (int i = 0; i < this.Methods.Length; i++)
-            {
-                if (!this.Methods[i].Equals(other.Methods[i]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return Internal.ModelEquality.SequenceEqual(this.InjectedMembersAssignments, other.InjectedMembersAssignments)
+                && Internal.ModelEquality.SequenceEqual(this.Methods, other.Methods);
         }
 
         public override bool Equals(object obj) => obj is ControllerModel other && this.Equals(other);
@@ -152,14 +135,20 @@ public sealed class PacketHandlerGenerator : IIncrementalGenerator
                 hash = (hash * 23) + (this.FullyQualifiedName?.GetHashCode() ?? 0);
                 hash = (hash * 23) + (this.Name?.GetHashCode() ?? 0);
                 hash = (hash * 23) + this.IsStatic.GetHashCode();
-                foreach (string a in this.InjectedMembersAssignments)
+                if (!this.InjectedMembersAssignments.IsDefaultOrEmpty)
                 {
-                    hash = (hash * 23) + (a?.GetHashCode() ?? 0);
+                    foreach (string a in this.InjectedMembersAssignments)
+                    {
+                        hash = (hash * 23) + (a?.GetHashCode() ?? 0);
+                    }
                 }
 
-                foreach (HandlerMethodModel m in this.Methods)
+                if (!this.Methods.IsDefaultOrEmpty)
                 {
-                    hash = (hash * 23) + m.GetHashCode();
+                    foreach (HandlerMethodModel m in this.Methods)
+                    {
+                        hash = (hash * 23) + m.GetHashCode();
+                    }
                 }
 
                 return hash;

--- a/analyzers/Nalix.Analyzers.Generators/RpcClientGenerator.cs
+++ b/analyzers/Nalix.Analyzers.Generators/RpcClientGenerator.cs
@@ -51,28 +51,23 @@ public sealed class RpcClientGenerator : IIncrementalGenerator
 
         public bool Equals(RpcMethodModel other)
         {
-            if (this.Name != other.Name || this.ReturnType != other.ReturnType || this.GenericArgument != other.GenericArgument || this.Parameters.Length != other.Parameters.Length)
+            if (this.Name != other.Name || this.ReturnType != other.ReturnType || this.GenericArgument != other.GenericArgument)
             {
                 return false;
             }
 
-            for (int i = 0; i < this.Parameters.Length; i++)
-            {
-                if (!this.Parameters[i].Equals(other.Parameters[i]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return Internal.ModelEquality.SequenceEqual(this.Parameters, other.Parameters);
         }
         public override bool Equals(object obj) => obj is RpcMethodModel other && this.Equals(other);
         public override int GetHashCode()
         {
             int hash = (this.Name, this.ReturnType, this.GenericArgument).GetHashCode();
-            foreach (RpcParameterModel p in this.Parameters)
+            if (!this.Parameters.IsDefaultOrEmpty)
             {
-                hash = (hash * 397) ^ p.GetHashCode();
+                foreach (RpcParameterModel p in this.Parameters)
+                {
+                    hash = (hash * 397) ^ p.GetHashCode();
+                }
             }
 
             return hash;
@@ -94,28 +89,23 @@ public sealed class RpcClientGenerator : IIncrementalGenerator
 
         public bool Equals(RpcServiceModel other)
         {
-            if (this.InterfaceName != other.InterfaceName || this.NamespaceName != other.NamespaceName || this.Methods.Length != other.Methods.Length)
+            if (this.InterfaceName != other.InterfaceName || this.NamespaceName != other.NamespaceName)
             {
                 return false;
             }
 
-            for (int i = 0; i < this.Methods.Length; i++)
-            {
-                if (!this.Methods[i].Equals(other.Methods[i]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return Internal.ModelEquality.SequenceEqual(this.Methods, other.Methods);
         }
         public override bool Equals(object obj) => obj is RpcServiceModel other && this.Equals(other);
         public override int GetHashCode()
         {
             int hash = (this.InterfaceName, this.NamespaceName).GetHashCode();
-            foreach (RpcMethodModel m in this.Methods)
+            if (!this.Methods.IsDefaultOrEmpty)
             {
-                hash = (hash * 397) ^ m.GetHashCode();
+                foreach (RpcMethodModel m in this.Methods)
+                {
+                    hash = (hash * 397) ^ m.GetHashCode();
+                }
             }
 
             return hash;

--- a/analyzers/Nalix.Analyzers.Generators/SerializeFormatterGenerator.cs
+++ b/analyzers/Nalix.Analyzers.Generators/SerializeFormatterGenerator.cs
@@ -75,35 +75,10 @@ public sealed class SerializeFormatterGenerator : IIncrementalGenerator
             }
 
             // NB: EnumTypes/TupleArgs may be default (uninitialized) when this model came from a
-            // `return default` path. ImmutableArray.SequenceEqual dereferences the backing array and
-            // throws NRE on a default value, which the incremental generator surfaces as an IDE-wide
-            // crash. Compare through the null-safe helper instead.
-            if (!SequenceEqualSafe(this.EnumTypes, other.EnumTypes))
-            {
-                return false;
-            }
-
-            if (!SequenceEqualSafe(this.TupleArgs, other.TupleArgs))
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        private static bool SequenceEqualSafe(ImmutableArray<string> left, ImmutableArray<string> right)
-        {
-            if (left.IsDefaultOrEmpty && right.IsDefaultOrEmpty)
-            {
-                return true;
-            }
-
-            if (left.IsDefaultOrEmpty || right.IsDefaultOrEmpty)
-            {
-                return false;
-            }
-
-            return left.SequenceEqual(right);
+            // `return default` path. Accessing a default ImmutableArray throws NRE, which the
+            // incremental generator surfaces as an IDE-wide crash. Compare through the null-safe helper.
+            return Internal.ModelEquality.SequenceEqual(this.EnumTypes, other.EnumTypes)
+                && Internal.ModelEquality.SequenceEqual(this.TupleArgs, other.TupleArgs);
         }
 
         public override bool Equals(object obj) => obj is SerializeFormatterModel other && this.Equals(other);

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<Version>14.2.1</Version>
+		<Version>14.2.3</Version>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Same class of crash as the SerializeFormatter fix, swept across all generators: model Equals/GetHashCode accessed ImmutableArray.Length or iterated the array while it could be default (null-backed) from a `return default` transform path. The incremental driver compares consecutive models in NodeStateTable.Builder.GetModifiedItemAndState BEFORE any `.Where(... != null)` filter, so default models reach these members and throw NullReferenceException, which Roslyn surfaces as an IDE-wide crash (classification, nav bar, diagnostics, source generation).

Added Internal.ModelEquality.SequenceEqual — a null-safe structural compare treating default/empty as equal — and routed every affected model through it:
- ConfigurationGenerator: ConfigPropertyModel, ConfigClassModel (reported)
- PacketHandlerGenerator: ControllerModel
- RpcClientGenerator: RpcMethodModel, RpcServiceModel
- SerializeFormatterGenerator: consolidated its local helper onto the shared one

GetHashCode foreach loops over the same arrays are now guarded with IsDefaultOrEmpty (foreach on a default ImmutableArray also throws).