### PR TITLE
fix(codec): propagate DAM annotations for consumer AOT trimming

### DIFF
--- a/analyzers/Nalix.Analyzers.Generators/Internal/ModelEquality.cs
+++ b/analyzers/Nalix.Analyzers.Generators/Internal/ModelEquality.cs
@@ -13,7 +13,7 @@ namespace Nalix.Analyzers.Generators.Internal;
 /// A model produced by a <c>return default</c> path carries <c>default</c> (null-backed) arrays. The
 /// incremental driver compares consecutive model values via <c>Equals</c> in
 /// <c>NodeStateTable.Builder.GetModifiedItemAndState</c>; any access to <see cref="ImmutableArray{T}.Length"/>
-/// or <see cref="ImmutableArray{T}.SequenceEqual"/> on a <c>default</c> value dereferences the null backing
+/// or <c>ImmutableArray{T}.SequenceEqual</c> on a <c>default</c> value dereferences the null backing
 /// array and throws <see cref="NullReferenceException"/>, which Roslyn surfaces as an IDE-wide crash. These
 /// helpers treat <c>default</c> and empty as equivalent so equality never touches the null backing array.
 /// </remarks>

--- a/src/Nalix.Codec/Serialization/FormatterProvider.cs
+++ b/src/Nalix.Codec/Serialization/FormatterProvider.cs
@@ -193,7 +193,11 @@ public static class FormatterProvider
     /// </summary>
     /// <typeparam name="T">The serialization target type.</typeparam>
     /// <param name="formatter">The source-generated formatter instance.</param>
-    public static void RegisterGenerated<T>(IFormatter<T> formatter)
+    public static void RegisterGenerated<
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicConstructors |
+            DynamicallyAccessedMemberTypes.PublicProperties |
+            DynamicallyAccessedMemberTypes.NonPublicProperties)] T>(IFormatter<T> formatter)
     {
         ArgumentNullException.ThrowIfNull(formatter);
         s_generatedFormatters[typeof(T)] = formatter;
@@ -205,7 +209,11 @@ public static class FormatterProvider
     /// Returns <see langword="null"/> if no generated formatter exists for the type.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static IFormatter<T>? TryGetGenerated<T>()
+    private static IFormatter<T>? TryGetGenerated<
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicConstructors |
+            DynamicallyAccessedMemberTypes.PublicProperties |
+            DynamicallyAccessedMemberTypes.NonPublicProperties)] T>()
     {
         if (s_generatedFormatters.TryGetValue(typeof(T), out object? obj))
         {
@@ -321,7 +329,11 @@ public static class FormatterProvider
     /// </summary>
     [DebuggerStepThrough]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Register<T>(IFormatter<T> formatter)
+    public static void Register<
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicConstructors |
+            DynamicallyAccessedMemberTypes.PublicProperties |
+            DynamicallyAccessedMemberTypes.NonPublicProperties)] T>(IFormatter<T> formatter)
     {
         ArgumentNullException.ThrowIfNull(formatter);
 
@@ -434,7 +446,11 @@ public static class FormatterProvider
     /// </summary>
     [DebuggerStepThrough]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IFormatter<T> GetComplex<T>()
+    public static IFormatter<T> GetComplex<
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicConstructors |
+            DynamicallyAccessedMemberTypes.PublicProperties |
+            DynamicallyAccessedMemberTypes.NonPublicProperties)] T>()
     {
         Type type = typeof(T);
 

--- a/src/Nalix.Codec/Serialization/Formatters/Cache/ComplexTypeCache.cs
+++ b/src/Nalix.Codec/Serialization/Formatters/Cache/ComplexTypeCache.cs
@@ -8,7 +8,11 @@ namespace Nalix.Codec.Serialization.Formatters.Cache;
 /// </summary>
 /// <typeparam name="T">The type for which the formatter is stored.</typeparam>
 [System.Diagnostics.DebuggerStepThrough]
-internal sealed class ComplexTypeCache<T>
+internal sealed class ComplexTypeCache<
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors |
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties |
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] T>
 {
     /// <summary>
     /// The cached formatter instance for the specified type <typeparamref name="T"/>.

--- a/src/Nalix.Codec/Serialization/Formatters/Cache/FormatterCache.cs
+++ b/src/Nalix.Codec/Serialization/Formatters/Cache/FormatterCache.cs
@@ -15,7 +15,11 @@ namespace Nalix.Codec.Serialization.Formatters.Cache;
 /// </summary>
 /// <typeparam name="T">The type for which the formatter is stored.</typeparam>
 [System.Diagnostics.DebuggerStepThrough]
-internal static class FormatterCache<T>
+internal static class FormatterCache<
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors |
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties |
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties)] T>
 {
     /// <summary>
     /// The cached formatter instance for the specified type <typeparamref name="T"/>.

--- a/src/Nalix.Environment/Diagnostics/DiagnosticListenerFactory.cs
+++ b/src/Nalix.Environment/Diagnostics/DiagnosticListenerFactory.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Nalix.Environment.Diagnostics;
@@ -20,6 +22,12 @@ public static class DiagnosticListenerFactory
     /// <returns>A safe <see cref="DiagnosticListener"/> instance.</returns>
     public static DiagnosticListener Create(string name)
     {
+        // DiagnosticListener cannot be constructed on Browser because the base
+        // constructor is unsupported. We intentionally bypass construction and
+        // override every virtual member to provide a safe no-op implementation.
+        //
+        // IMPORTANT:
+        // Do not access any DiagnosticListener base members from this type.
         if (OperatingSystem.IsBrowser())
         {
             return (DiagnosticListener)RuntimeHelpers.GetUninitializedObject(typeof(BrowserSafeDiagnosticListener));
@@ -35,8 +43,9 @@ public static class DiagnosticListenerFactory
 /// </summary>
 internal sealed class BrowserSafeDiagnosticListener : DiagnosticListener
 {
-    // Required to satisfy the compiler, but will be bypassed during instantiation via GetUninitializedObject.
-    public BrowserSafeDiagnosticListener() : base("Safe")
+    // Never executed when instantiated via RuntimeHelpers.GetUninitializedObject.
+    public BrowserSafeDiagnosticListener()
+        : base("BrowserSafe")
     {
     }
 
@@ -44,8 +53,28 @@ internal sealed class BrowserSafeDiagnosticListener : DiagnosticListener
 
     public override bool IsEnabled(string? name, object? arg1, object? arg2 = null) => false;
 
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("DiagnosticSource.Write requires unreferenced code analysis for payload property discovery.")]
-    public override void Write(string name, object? value)
+    public override IDisposable Subscribe(IObserver<KeyValuePair<string, object?>> observer) => NoOpDisposable.Instance;
+
+    public override IDisposable Subscribe(IObserver<KeyValuePair<string, object?>> observer, Predicate<string>? isEnabled) => NoOpDisposable.Instance;
+
+    public override IDisposable Subscribe(IObserver<KeyValuePair<string, object?>> observer, Func<string, object?, object?, bool>? isEnabled) => NoOpDisposable.Instance;
+
+    public override IDisposable Subscribe(IObserver<KeyValuePair<string, object?>> observer, Func<string, object?, object?, bool>? isEnabled, Action<Activity, object?>? onActivityImport = null, Action<Activity, object?>? onActivityExport = null) => NoOpDisposable.Instance;
+
+    /// <inheritdoc/>
+    [SuppressMessage("Usage", "CA2215:Dispose methods should call base class dispose", Justification = "<Pending>")]
+    public override void Dispose() { }
+
+    [RequiresUnreferencedCode(
+        "DiagnosticSource.Write requires unreferenced code analysis for payload property discovery.")]
+    public override void Write(string name, object? value) { }
+
+    private sealed class NoOpDisposable : IDisposable
     {
+        public static readonly NoOpDisposable Instance = new();
+
+        private NoOpDisposable() { }
+
+        public void Dispose() { }
     }
 }

--- a/src/Nalix.Framework/Injection/InstanceManager.cs
+++ b/src/Nalix.Framework/Injection/InstanceManager.cs
@@ -135,7 +135,7 @@ public sealed partial class InstanceManager : SingletonBase<InstanceManager>, IR
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public void Register<T>(T instance) where T : class
     {
-        THROW_IF_LOCKED();
+        this.THROW_IF_LOCKED();
 
         ObjectDisposedException.ThrowIf(Interlocked.CompareExchange(ref _isDisposed, 0, 0) != 0, nameof(InstanceManager));
 
@@ -393,7 +393,7 @@ public sealed partial class InstanceManager : SingletonBase<InstanceManager>, IR
     public bool RemoveInstance(Type type)
     {
         ObjectDisposedException.ThrowIf(Interlocked.CompareExchange(ref _isDisposed, 0, 0) != 0, nameof(InstanceManager));
-        THROW_IF_LOCKED();
+        this.THROW_IF_LOCKED();
 
         ArgumentNullException.ThrowIfNull(type, nameof(type));
 
@@ -551,7 +551,7 @@ public sealed partial class InstanceManager : SingletonBase<InstanceManager>, IR
     public void Clear(bool dispose = true)
     {
         ObjectDisposedException.ThrowIf(Interlocked.CompareExchange(ref _isDisposed, 0, 0) != 0, nameof(InstanceManager));
-        THROW_IF_LOCKED();
+        this.THROW_IF_LOCKED();
         this.ClearInternal(dispose);
     }
 

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<Version>14.2.3</Version>
+		<Version>14.2.4</Version>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Add DynamicallyAccessedMembers to FormatterCache<T>, ComplexTypeCache<T>, and FormatterProvider.GetComplex/Register/TryGetGenerated/RegisterGenerated to match IFormatter<T>, eliminating IL2091/IL2104 for consumers publishing with PublishAot. No API or runtime behavior change.

Also fixes remaining build warnings: CS1574 doc cref, IDE0009 qualification, and browser-safe DiagnosticListener no-op overrides. Bumps version to 14.2.4.
