### PR TITLE
fix(network): validate WebSocket Origin header (CSWSH protection) (#298)

### DIFF
--- a/src/Nalix.Network/Listeners/WebListener/WebSocketListener.Handle.cs
+++ b/src/Nalix.Network/Listeners/WebListener/WebSocketListener.Handle.cs
@@ -155,6 +155,18 @@ public abstract partial class WebSocketListenerBase
                         continue;
                     }
 
+                    // 2. Validate the Origin header to block Cross-Site WebSocket Hijacking (CSWSH).
+                    // WHY here: after the rate limiter (so an origin-spoofing flood is still throttled)
+                    // but before AcceptWebSocketAsync, so a rejected browser page never triggers the
+                    // SHA1 handshake or any allocation. No-op when the allowlist is empty (legacy behavior).
+                    if (!_config.IsOriginAllowed(context.Request.Headers["Origin"]))
+                    {
+                        this.Metrics.RECORD_REJECTED();
+                        context.Response.StatusCode = 403; // Forbidden
+                        context.Response.Close();
+                        continue;
+                    }
+
                     HttpListenerWebSocketContext wsContext;
                     try
                     {

--- a/src/Nalix.Network/Options/NetworkWebSocketOptions.cs
+++ b/src/Nalix.Network/Options/NetworkWebSocketOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+using System;
 using Nalix.Abstractions;
 using Nalix.Abstractions.Validation;
 using Nalix.Environment.Configuration.Binding;
@@ -87,6 +88,86 @@ public sealed partial class NetworkWebSocketOptions : ConfigurationLoader, IVali
     [IniComment("Number of concurrent accept workers (default 1)")]
     [ValueRange(1, 1024)]
     public int MaxParallel { get; set; } = 1;
+
+    /// <summary>
+    /// Comma-separated allowlist of browser origins (scheme+host+port) permitted to open a
+    /// WebSocket handshake, e.g. <c>https://schools.eyc.education,https://app.example.com</c>.
+    /// Empty disables the check (legacy behavior). Guards against Cross-Site WebSocket Hijacking (CSWSH).
+    /// </summary>
+    [IniComment("Comma-separated allowed browser origins for CSWSH protection; empty disables the check (default empty)")]
+    public string AllowedOrigins { get; set; } = string.Empty;
+
+    /// <summary>
+    /// When an allowlist is configured, controls whether a handshake without an <c>Origin</c> header
+    /// (non-browser/native clients) is permitted. Ignored when <see cref="AllowedOrigins"/> is empty.
+    /// </summary>
+    [IniComment("Allow handshakes with no Origin header (native clients) when an allowlist is set (default true)")]
+    public bool AllowMissingOrigin { get; set; } = true;
+
+    // ponytail: cache is rebuilt when the source string reference changes; races between accept
+    // workers are benign (idempotent rebuild). Upgrade to a lock only if origins become mutable at runtime.
+    private string? _originsSource;
+    private string[] _originsCache = [];
+
+    /// <summary>
+    /// Determines whether a handshake carrying the given <c>Origin</c> header value is allowed.
+    /// </summary>
+    /// <param name="origin">The raw <c>Origin</c> header value, or <c>null</c> when absent.</param>
+    /// <returns><c>true</c> if the handshake may proceed; otherwise <c>false</c>.</returns>
+    internal bool IsOriginAllowed(string? origin)
+    {
+        string[] allow = this.GetAllowedOriginsCache();
+
+        // Empty allowlist => feature disabled, legacy behavior (cheapest path, no allocation).
+        if (allow.Length == 0)
+        {
+            return true;
+        }
+
+        if (string.IsNullOrEmpty(origin))
+        {
+            return this.AllowMissingOrigin;
+        }
+
+        System.ReadOnlySpan<char> normalized = origin.AsSpan().Trim().TrimEnd('/');
+        for (int i = 0; i < allow.Length; i++)
+        {
+            if (normalized.Equals(allow[i], System.StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private string[] GetAllowedOriginsCache()
+    {
+        string source = this.AllowedOrigins ?? string.Empty;
+        if (!ReferenceEquals(source, _originsSource))
+        {
+            _originsCache = ParseOrigins(source);
+            _originsSource = source;
+        }
+
+        return _originsCache;
+    }
+
+    private static string[] ParseOrigins(string source)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            return [];
+        }
+
+        string[] parts = source.Split(',', System.StringSplitOptions.RemoveEmptyEntries | System.StringSplitOptions.TrimEntries);
+        for (int i = 0; i < parts.Length; i++)
+        {
+            parts[i] = parts[i].TrimEnd('/');
+        }
+
+        return parts;
+    }
 
     /// <summary>
     /// Validates the configuration options and throws an exception if validation fails.

--- a/tests/Nalix.Network.Tests/WebSocketOriginValidationTests.cs
+++ b/tests/Nalix.Network.Tests/WebSocketOriginValidationTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using Nalix.Network.Options;
+using Xunit;
+
+namespace Nalix.Network.Tests;
+
+/// <summary>
+/// Verifies CSWSH Origin-header validation on <see cref="NetworkWebSocketOptions.IsOriginAllowed"/>.
+/// Covers issue #298 acceptance criteria: authorized, unauthorized, missing, and empty-allowlist cases.
+/// </summary>
+public class WebSocketOriginValidationTests
+{
+    [Fact]
+    public void EmptyAllowlist_AllowsAnyOrigin_LegacyBehavior()
+    {
+        NetworkWebSocketOptions opt = new() { AllowedOrigins = string.Empty };
+
+        Assert.True(opt.IsOriginAllowed("https://evil.example"));
+        Assert.True(opt.IsOriginAllowed(null));
+        Assert.True(opt.IsOriginAllowed(""));
+    }
+
+    [Fact]
+    public void AuthorizedOrigin_IsAllowed()
+    {
+        NetworkWebSocketOptions opt = new() { AllowedOrigins = "https://schools.eyc.education,https://app.example.com" };
+
+        Assert.True(opt.IsOriginAllowed("https://schools.eyc.education"));
+        Assert.True(opt.IsOriginAllowed("https://app.example.com"));
+    }
+
+    [Fact]
+    public void UnauthorizedOrigin_IsRejected()
+    {
+        NetworkWebSocketOptions opt = new() { AllowedOrigins = "https://schools.eyc.education" };
+
+        Assert.False(opt.IsOriginAllowed("https://evil.example"));
+        Assert.False(opt.IsOriginAllowed("http://schools.eyc.education")); // scheme mismatch
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MissingOrigin_FollowsAllowMissingOriginSetting(bool allowMissing)
+    {
+        NetworkWebSocketOptions opt = new()
+        {
+            AllowedOrigins = "https://schools.eyc.education",
+            AllowMissingOrigin = allowMissing,
+        };
+
+        Assert.Equal(allowMissing, opt.IsOriginAllowed(null));
+        Assert.Equal(allowMissing, opt.IsOriginAllowed(""));
+    }
+
+    [Fact]
+    public void OriginMatch_IsCaseInsensitive_AndIgnoresTrailingSlash()
+    {
+        NetworkWebSocketOptions opt = new() { AllowedOrigins = "https://schools.eyc.education" };
+
+        Assert.True(opt.IsOriginAllowed("HTTPS://Schools.EYC.Education"));
+        Assert.True(opt.IsOriginAllowed("https://schools.eyc.education/"));
+        Assert.True(opt.IsOriginAllowed(" https://schools.eyc.education "));
+    }
+
+    [Fact]
+    public void Allowlist_TrimsEntriesAndTrailingSlashes()
+    {
+        NetworkWebSocketOptions opt = new() { AllowedOrigins = " https://a.com/ , https://b.com " };
+
+        Assert.True(opt.IsOriginAllowed("https://a.com"));
+        Assert.True(opt.IsOriginAllowed("https://b.com"));
+    }
+
+    [Fact]
+    public void CacheRebuilds_WhenAllowedOriginsChanges()
+    {
+        NetworkWebSocketOptions opt = new() { AllowedOrigins = "https://a.com" };
+        Assert.True(opt.IsOriginAllowed("https://a.com"));
+        Assert.False(opt.IsOriginAllowed("https://b.com"));
+
+        opt.AllowedOrigins = "https://b.com";
+        Assert.False(opt.IsOriginAllowed("https://a.com"));
+        Assert.True(opt.IsOriginAllowed("https://b.com"));
+    }
+}


### PR DESCRIPTION
Add NetworkWebSocketOptions.AllowedOrigins (CSV) and AllowMissingOrigin. Reject unauthorized browser origins with HTTP 403 during the upgrade handshake, after the rate limiter and before AcceptWebSocketAsync so no SHA1/allocation is spent on blocked pages. Empty allowlist preserves legacy behavior (no check, zero-alloc early return).