### PR TITLE
fix(codec): allow zero-payload frame encryption (#300)

### DIFF
--- a/src/Nalix.Codec/Transforms/FrameTransformer.cs
+++ b/src/Nalix.Codec/Transforms/FrameTransformer.cs
@@ -191,7 +191,7 @@ public static class FrameTransformer
             Throw.EncryptionKeyEmpty();
         }
 
-        if (src.Length <= Offset)
+        if (src.Length < Offset)
         {
             Throw.SourceTooSmall();
         }
@@ -239,7 +239,7 @@ public static class FrameTransformer
             Throw.EncryptionKeyEmpty();
         }
 
-        if (src.Length <= Offset)
+        if (src.Length < Offset)
         {
             Throw.SourceTooSmall();
         }

--- a/tests/Nalix.Codec.Tests/DataFrames/PacketTransformTests.cs
+++ b/tests/Nalix.Codec.Tests/DataFrames/PacketTransformTests.cs
@@ -54,6 +54,27 @@ public sealed class PacketTransformTests
     }
 
     [Fact]
+    public void FrameCipher_ZeroPayload_RoundtripShouldSucceed()
+    {
+        // Regression for #300: a header-only frame (Length == Offset, no payload)
+        // must encrypt/decrypt symmetrically instead of tripping SourceTooSmall.
+        using BufferLease src = BufferLease.Rent(FrameTransformer.Offset);
+        src.CommitLength(FrameTransformer.Offset);
+
+        src.Span[..FrameTransformer.Offset].Clear();
+        src.Span.AsHeaderRef() = new PacketHeader { Flags = PacketFlags.NONE };
+
+        using IBufferLease encrypted = FrameCipher.EncryptFrame(src, s_testKey, null, CipherSuiteType.Chacha20Poly1305);
+
+        Assert.True(encrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
+
+        using IBufferLease decrypted = FrameCipher.DecryptFrame(encrypted, s_testKey, CipherSuiteType.Chacha20Poly1305, out _);
+
+        Assert.False(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.Equal(FrameTransformer.Offset, decrypted.Length);
+    }
+
+    [Fact]
     public void FrameCompression_Roundtrip_ShouldSucceed()
     {
         // 1. Arrange


### PR DESCRIPTION
FrameTransformer.Encrypt/Decrypt guarded with `src.Length <= Offset`, tripping SourceTooSmall for header-only frames (Length == Offset, e.g. field-less SignalPacket heartbeats/acks). Such frames serialize and round-trip fine unencrypted, so the asymmetry was a defect. The AEAD engine and envelope parser already handle zero-length plaintext.

Relax both guards to `< Offset` so empty payloads encrypt/decrypt symmetrically. Add a regression round-trip test for a 6-byte frame.