### PR TITLE
fix(network): group observer, session expiry buckets

### DIFF
--- a/src/Nalix.Hosting/Internal/ServiceRegistrar.cs
+++ b/src/Nalix.Hosting/Internal/ServiceRegistrar.cs
@@ -15,6 +15,7 @@ using Nalix.Framework.Memory.Buffers;
 using Nalix.Framework.Memory.Objects;
 using Nalix.Network.Connections;
 using Nalix.Network.RateLimiting;
+using Nalix.Runtime.Groups;
 using Nalix.Runtime.Routing;
 using Nalix.Runtime.Sessions;
 
@@ -81,6 +82,31 @@ internal static class ServiceRegistrar
                 SessionPersistenceObserver observer = new(hub, service);
 #pragma warning restore CA2000 // Dispose objects before losing scope
                 InstanceManager.Instance.Register<SessionPersistenceObserver>(observer);
+            }
+        }
+    }
+
+    public static void RegisterGroups()
+    {
+        IConnectionGroupRegistry? registry = InstanceManager.Instance.GetExistingInstance<IConnectionGroupRegistry>();
+
+        if (registry == null)
+        {
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            registry = new InMemoryGroupStore();
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            InstanceManager.Instance.Register<IConnectionGroupRegistry>(registry);
+        }
+
+        if (InstanceManager.Instance.GetExistingInstance<GroupMembershipObserver>() == null)
+        {
+            IConnectionHub? hub = InstanceManager.Instance.GetExistingInstance<IConnectionHub>();
+            if (hub is not null)
+            {
+#pragma warning disable CA2000 // Dispose objects before losing scope
+                GroupMembershipObserver observer = new(hub, registry);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+                InstanceManager.Instance.Register<GroupMembershipObserver>(observer);
             }
         }
     }

--- a/src/Nalix.Hosting/NetworkApplicationBuilder.Extensions.cs
+++ b/src/Nalix.Hosting/NetworkApplicationBuilder.Extensions.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using Nalix.Abstractions.Networking;
 using Nalix.Abstractions.Networking.Sessions;
 using Nalix.Abstractions.Security;
 using Nalix.Framework.Injection;
 using Nalix.Hosting.Internal;
 using Nalix.Network.RateLimiting;
+using Nalix.Runtime.Groups;
 using Nalix.Runtime.Handlers;
 using Nalix.Runtime.Security;
 using Nalix.Runtime.Sessions;
@@ -104,6 +106,24 @@ public static class NetworkApplicationBuilderExtensions
         _ = builder.MapHandlers(typeof(SessionHandlers));
 
         ServiceRegistrar.RegisterSessions();
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Enables connection group management. Registers an
+    /// <see cref="IConnectionGroupRegistry"/> (defaulting to
+    /// <see cref="InMemoryGroupStore"/>) and a
+    /// <see cref="GroupMembershipObserver"/> that automatically removes a
+    /// connection from all its groups when the connection hub unregisters it.
+    /// </summary>
+    /// <param name="builder">The application builder.</param>
+    /// <returns>The current builder instance.</returns>
+    public static INetworkApplicationBuilder UseGroups(this INetworkApplicationBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        ServiceRegistrar.RegisterGroups();
 
         return builder;
     }

--- a/src/Nalix.Runtime/Groups/GroupMembershipObserver.cs
+++ b/src/Nalix.Runtime/Groups/GroupMembershipObserver.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using Nalix.Abstractions.Networking;
+
+namespace Nalix.Runtime.Groups;
+
+/// <summary>
+/// Observes connection unregistrations and removes the connection from all groups.
+/// Decouples the group registry from the connection hub.
+/// </summary>
+public sealed class GroupMembershipObserver : IDisposable
+{
+    private bool _disposed;
+
+    private readonly IConnectionHub _hub;
+    private readonly IConnectionGroupRegistry _registry;
+
+    /// <summary>
+    /// Initializes a new instance of the GroupMembershipObserver and subscribes to hub events.
+    /// </summary>
+    public GroupMembershipObserver(IConnectionHub hub, IConnectionGroupRegistry registry)
+    {
+        _hub = hub ?? throw new ArgumentNullException(nameof(hub));
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+
+        _hub.ConnectionUnregistered += this.OnConnectionClosed;
+    }
+
+    private void OnConnectionClosed(IConnection connection) => _ = _registry.RemoveFromAllGroupsAsync(connection);
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        _hub.ConnectionUnregistered -= this.OnConnectionClosed;
+    }
+}

--- a/src/Nalix.Runtime/Sessions/InMemorySessionStore.cs
+++ b/src/Nalix.Runtime/Sessions/InMemorySessionStore.cs
@@ -26,10 +26,26 @@ namespace Nalix.Runtime.Sessions;
     Tag = TaskNaming.Tags.Cleanup, IdType = 1, RetainForMs = 0)]
 public sealed class InMemorySessionStore : ISessionStore, IWorker, IReportable
 {
+    // Bucketing granularity for the expiry index. Sessions expiring within the
+    // same minute share a bucket, so the scavenger only visits buckets that are
+    // actually due instead of scanning every live session every pass.
+    private const long BucketSpanMilliseconds = 60_000;
+
     private readonly ConcurrentDictionary<ulong, SessionEntry> _store = new();
+
+    // expiryBucket (ExpiresAtUnixMilliseconds / BucketSpanMilliseconds) -> session tokens due in that bucket.
+    // A stale entry (session consumed/removed, or re-stored with a later expiry) is harmless: the bucket
+    // is only ever a hint, the real expiry is re-checked against _store before anything is removed.
+    private readonly ConcurrentDictionary<long, ConcurrentDictionary<ulong, byte>> _expiryBuckets = new();
+
     private long _totalStored;
     private long _totalConsumed;
     private long _totalExpired;
+
+    private static long BucketOf(long expiresAtUnixMilliseconds) => expiresAtUnixMilliseconds / BucketSpanMilliseconds;
+
+    private void IndexExpiry(ulong token, long expiresAtUnixMilliseconds)
+        => _expiryBuckets.GetOrAdd(BucketOf(expiresAtUnixMilliseconds), static _ => new ConcurrentDictionary<ulong, byte>())[token] = 1;
 
     /// <summary>
     /// Executes the scavenging loop. This method is intended to be called by a <see cref="ITaskManager"/> worker.
@@ -44,7 +60,7 @@ public sealed class InMemorySessionStore : ISessionStore, IWorker, IReportable
 
             try
             {
-                await SCAVENGE_ASYNC(this, _store, cancellationToken).ConfigureAwait(false);
+                await SCAVENGE_ASYNC(this, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
@@ -52,28 +68,46 @@ public sealed class InMemorySessionStore : ISessionStore, IWorker, IReportable
             }
         }
 
-        static async ValueTask SCAVENGE_ASYNC(InMemorySessionStore self, ConcurrentDictionary<ulong, SessionEntry> store, CancellationToken cancellationToken)
+        static async ValueTask SCAVENGE_ASYNC(InMemorySessionStore self, CancellationToken cancellationToken)
         {
             long now = Clock.UnixMillisecondsNow();
+            long dueBucket = BucketOf(now);
             int count = 0;
 
-            foreach (KeyValuePair<ulong, SessionEntry> pair in store)
+            foreach (long bucketKey in self._expiryBuckets.Keys)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
                     break;
                 }
 
-                if (pair.Value.Snapshot.ExpiresAtUnixMilliseconds <= now &&
-                    ((ICollection<KeyValuePair<ulong, SessionEntry>>)store).Remove(pair))
+                if (bucketKey > dueBucket || !self._expiryBuckets.TryRemove(bucketKey, out ConcurrentDictionary<ulong, byte>? tokens))
                 {
-                    _ = Interlocked.Increment(ref self._totalExpired);
-                    pair.Value.Return();
+                    continue;
                 }
 
-                if (++count % 1000 == 0)
+                foreach (ulong token in tokens.Keys)
                 {
-                    await Task.Yield();
+                    // Bucket membership is only a hint (a session re-stored with a later
+                    // expiry may still sit in an earlier bucket) — re-check the live
+                    // expiry and re-index it if it hasn't actually expired yet.
+                    if (self._store.TryGetValue(token, out SessionEntry? entry))
+                    {
+                        if (entry.Snapshot.ExpiresAtUnixMilliseconds > now)
+                        {
+                            self.IndexExpiry(token, entry.Snapshot.ExpiresAtUnixMilliseconds);
+                        }
+                        else if (((ICollection<KeyValuePair<ulong, SessionEntry>>)self._store).Remove(new KeyValuePair<ulong, SessionEntry>(token, entry)))
+                        {
+                            _ = Interlocked.Increment(ref self._totalExpired);
+                            entry.Return();
+                        }
+                    }
+
+                    if (++count % 1000 == 0)
+                    {
+                        await Task.Yield();
+                    }
                 }
             }
         }
@@ -95,6 +129,7 @@ public sealed class InMemorySessionStore : ISessionStore, IWorker, IReportable
             if (_store.TryAdd(token, entry))
             {
                 _ = Interlocked.Increment(ref _totalStored);
+                this.IndexExpiry(token, entry.Snapshot.ExpiresAtUnixMilliseconds);
                 return ValueTask.CompletedTask;
             }
 
@@ -112,6 +147,7 @@ public sealed class InMemorySessionStore : ISessionStore, IWorker, IReportable
             if (_store.TryUpdate(token, entry, current))
             {
                 _ = Interlocked.Increment(ref _totalStored);
+                this.IndexExpiry(token, entry.Snapshot.ExpiresAtUnixMilliseconds);
                 current.Return();
                 return ValueTask.CompletedTask;
             }

--- a/tests/Nalix.Network.Tests/WebSocketGroupBroadcastTests.cs
+++ b/tests/Nalix.Network.Tests/WebSocketGroupBroadcastTests.cs
@@ -218,6 +218,46 @@ public sealed class WebSocketGroupBroadcastTests : IDisposable
     }
 
     [Fact]
+    public async Task ConnectionUnregistered_WithoutObserver_LeavesConnectionInGroupStore()
+    {
+        // Without GroupMembershipObserver wired up, ConnectionHub.ConnectionUnregistered
+        // has no subscriber that cleans up group membership, so a disconnected
+        // connection stays in its groups forever (stale reference).
+        using ConnectionHub hub = new();
+        InMemoryGroupStore groupStore = new();
+
+        using TrackingStubWebSocket socket1 = new();
+        WebSocketConnection ws1 = new(socket1, _extractor, new IPEndPoint(IPAddress.Loopback, 8081));
+
+        hub.RegisterConnection(ws1);
+        await groupStore.AddToGroupAsync("room1", ws1);
+
+        ws1.Dispose(); // triggers ConnectionClosed -> hub unregisters -> fires ConnectionUnregistered
+
+        groupStore.GetGroupMembers("room1").Should().Contain(ws1,
+            "no observer is subscribed, so nothing removes the connection from its groups");
+    }
+
+    [Fact]
+    public async Task ConnectionUnregistered_WithObserver_RemovesConnectionFromGroupStore()
+    {
+        using ConnectionHub hub = new();
+        InMemoryGroupStore groupStore = new();
+        using GroupMembershipObserver observer = new(hub, groupStore);
+
+        using TrackingStubWebSocket socket1 = new();
+        WebSocketConnection ws1 = new(socket1, _extractor, new IPEndPoint(IPAddress.Loopback, 8081));
+
+        hub.RegisterConnection(ws1);
+        await groupStore.AddToGroupAsync("room1", ws1);
+
+        ws1.Dispose(); // triggers ConnectionClosed -> hub unregisters -> observer removes from groups
+
+        groupStore.GetGroupMembers("room1").Should().BeEmpty(
+            "GroupMembershipObserver must remove the connection from all groups on disconnect");
+    }
+
+    [Fact]
     public async Task MulticastAsync_EmptyGroup_ReturnsImmediately()
     {
         using ConnectionHub hub = new();


### PR DESCRIPTION
Introduce GroupMembershipObserver to decouple group cleanup from the connection hub. Add ServiceRegistrar.RegisterGroups and UseGroups() for group management registration. Optimize InMemorySessionStore scavenging with expiry buckets and ensure expiry indexing on add/update. Add tests verifying group cleanup behavior with and without the observer.