### PR TITLE
fix: ini config duplicate comments

### DIFF
--- a/src/Nalix.Environment/Configuration/Binding/IniConfig.cs
+++ b/src/Nalix.Environment/Configuration/Binding/IniConfig.cs
@@ -1448,8 +1448,20 @@ public sealed class IniConfig : IDisposable
                         {
                             // Property-level comment lines go directly above their key=value line
                             // so Load() can re-associate them with the correct key on round-trip.
-                            this.WriteInlineComment(writer, section.Key,
-                                commentKey: CreateCacheKey(section.Key, keyValue.Key));
+                            string commentKey = CreateCacheKey(section.Key, keyValue.Key);
+
+                            // Normalize round-tripped on-disk comments ("Key: ...") back to the stored
+                            // form ("...") so WriteInlineComment doesn't double-prefix on each flush.
+                            if (_comments.TryGetValue(commentKey, out string? comment)
+                                && comment.Length >= keyValue.Key.Length + 2
+                                && comment.StartsWith(keyValue.Key, StringComparison.Ordinal)
+                                && comment[keyValue.Key.Length] == ':'
+                                && comment[keyValue.Key.Length + 1] == ' ')
+                            {
+                                _comments[commentKey] = comment[(keyValue.Key.Length + 2)..];
+                            }
+
+                            this.WriteInlineComment(writer, section.Key, commentKey: commentKey);
 
                             writer.Write(keyValue.Key.PadRight(maxKeyLength));
                             writer.Write(" = ");

--- a/src/Nalix.Environment/Configuration/Binding/IniConfig.cs
+++ b/src/Nalix.Environment/Configuration/Binding/IniConfig.cs
@@ -1418,41 +1418,11 @@ public sealed class IniConfig : IDisposable
                             string sectionCommentKey = section.Key;
                             bool hasSectionComment = _comments.ContainsKey(sectionCommentKey);
 
-                            // Check whether any key in this section has a comment
-                            bool hasAnyKeyComment = false;
-                            foreach (KeyValuePair<string, string> kv in section.Value)
-                            {
-                                if (_comments.ContainsKey(CreateCacheKey(section.Key, kv.Key)))
-                                {
-                                    hasAnyKeyComment = true;
-                                    break;
-                                }
-                            }
-
-                            bool hasAnyComment = hasSectionComment || hasAnyKeyComment;
-
-                            // ── Opening separator ────────────────────────────────────
-                            if (hasAnyComment)
-                            {
-                                writer.WriteLine(s_sectionSeparator);
-                            }
-
-                            // ── Section-level comment lines ──────────────────────────
+                            // ── Section-level comment lines (wrapped in separators) ──
                             if (hasSectionComment)
                             {
+                                writer.WriteLine(s_sectionSeparator);
                                 this.WriteInlineComment(writer, section.Key, commentKey: sectionCommentKey);
-                            }
-
-                            // ── Property-level comment lines (above the section header)
-                            foreach (KeyValuePair<string, string> keyValue in section.Value)
-                            {
-                                this.WriteInlineComment(writer, section.Key,
-                                    commentKey: CreateCacheKey(section.Key, keyValue.Key));
-                            }
-
-                            // ── Closing separator (only when there were comment lines) ─
-                            if (hasAnyComment)
-                            {
                                 writer.WriteLine(s_sectionSeparator);
                             }
 
@@ -1476,6 +1446,11 @@ public sealed class IniConfig : IDisposable
 
                         foreach (KeyValuePair<string, string> keyValue in section.Value)
                         {
+                            // Property-level comment lines go directly above their key=value line
+                            // so Load() can re-associate them with the correct key on round-trip.
+                            this.WriteInlineComment(writer, section.Key,
+                                commentKey: CreateCacheKey(section.Key, keyValue.Key));
+
                             writer.Write(keyValue.Key.PadRight(maxKeyLength));
                             writer.Write(" = ");
                             writer.WriteLine(keyValue.Value);

--- a/src/Nalix.SDK/Transport/Internal/ReconnectSupervisor.cs
+++ b/src/Nalix.SDK/Transport/Internal/ReconnectSupervisor.cs
@@ -40,6 +40,10 @@ internal sealed class ReconnectSupervisor
         return tcs is null ? Task.CompletedTask : tcs.Task.WaitAsync(ct);
     }
 
+    // ponytail: OnDisconnected fires for both unexpected drops and explicit DisconnectAsync()
+    // calls, so an app-initiated disconnect while AutoReconnectEnabled is on will also trigger
+    // a reconnect attempt. Fixing this requires an intentional-disconnect signal plumbed through
+    // TcpSession/UdpSession/WebSocketSession; add if this becomes a real usage pattern.
     private void OnDisconnected(object? sender, Exception ex)
     {
         if (!_session.Options.AutoReconnectEnabled)

--- a/src/Nalix.SDK/Transport/Internal/ReconnectSupervisor.cs
+++ b/src/Nalix.SDK/Transport/Internal/ReconnectSupervisor.cs
@@ -40,10 +40,9 @@ internal sealed class ReconnectSupervisor
         return tcs is null ? Task.CompletedTask : tcs.Task.WaitAsync(ct);
     }
 
-    // ponytail: OnDisconnected fires for both unexpected drops and explicit DisconnectAsync()
-    // calls, so an app-initiated disconnect while AutoReconnectEnabled is on will also trigger
-    // a reconnect attempt. Fixing this requires an intentional-disconnect signal plumbed through
-    // TcpSession/UdpSession/WebSocketSession; add if this becomes a real usage pattern.
+    // OnDisconnected fires for both unexpected drops and explicit DisconnectAsync() calls.
+    // Concrete sessions should call TransportSession.MarkIntentionalDisconnect() from DisconnectAsync()
+    // so ConsumeIntentionalDisconnect() can prevent auto-reconnect for app-initiated disconnects.
     private void OnDisconnected(object? sender, Exception ex)
     {
         if (!_session.Options.AutoReconnectEnabled)

--- a/tests/Nalix.Environment.Tests/Configuration/IniConfigTests.cs
+++ b/tests/Nalix.Environment.Tests/Configuration/IniConfigTests.cs
@@ -39,6 +39,23 @@ public class IniConfigTests : IDisposable
         // Should still be 1, not 11 or more
         Assert.Single(comments);
     }
+
+    [Fact]
+    public void RepeatedBoot_DoesNotDuplicatePropertyComment()
+    {
+        // Simulates the ConfigurationLoader boot sequence: each start re-registers
+        // the property comment via WriteComment(), then flushes.
+        for (int i = 0; i < 5; i++)
+        {
+            using IniConfig config = new(_path);
+            config.WriteComment("Section", "Key", "Key: description");
+            config.Flush();
+        }
+
+        string content = File.ReadAllText(_path);
+        int occurrences = System.Text.RegularExpressions.Regex.Matches(content, "Key: description").Count;
+        Assert.Equal(1, occurrences);
+    }
 }
 #endif
 

--- a/tests/Nalix.Environment.Tests/Configuration/IniConfigTests.cs
+++ b/tests/Nalix.Environment.Tests/Configuration/IniConfigTests.cs
@@ -43,17 +43,24 @@ public class IniConfigTests : IDisposable
     [Fact]
     public void RepeatedBoot_DoesNotDuplicatePropertyComment()
     {
-        // Simulates the ConfigurationLoader boot sequence: each start re-registers
-        // the property comment via WriteComment(), then flushes.
+        // Start from a file that has the section but no key/comment yet.
+        File.WriteAllText(_path, "[Section]\n");
+
+        // Repeated open/write/flush cycles should not duplicate or "grow" the property comment.
         for (int i = 0; i < 5; i++)
         {
             using IniConfig config = new(_path);
-            config.WriteComment("Section", "Key", "Key: description");
+            config.WriteComment("Section", "Key", "description");
+            config.WriteValue("Section", "Key", $"Value{i}");
             config.Flush();
         }
 
-        string content = File.ReadAllText(_path);
-        int occurrences = System.Text.RegularExpressions.Regex.Matches(content, "Key: description").Count;
+        string content = File.ReadAllText(_path).Replace("\r\n", "\n");
+        int occurrences = System.Text.RegularExpressions.Regex.Matches(
+            content,
+            @"^; Key: description$",
+            System.Text.RegularExpressions.RegexOptions.Multiline).Count;
+
         Assert.Equal(1, occurrences);
     }
 }


### PR DESCRIPTION
This pull request refines how comments are written in INI configuration files to ensure property-level comments are not duplicated and are consistently placed above their associated keys. It also adds a regression test to prevent comment duplication and clarifies reconnect behavior in the SDK.

**Improvements to INI file comment handling:**

* Property-level comments are now always written directly above their corresponding `key=value` line, ensuring correct round-trip association and preventing duplication. Section-level comments are wrapped with separators only if present, and opening/closing separators are no longer written just because a key has a comment. (`src/Nalix.Environment/Configuration/Binding/IniConfig.cs`) [[1]](diffhunk://#diff-ed210028873493713af2cc9693eb99a078da299e3cdd0cb0d00c060fb5df4e3cL1421-L1455) [[2]](diffhunk://#diff-ed210028873493713af2cc9693eb99a078da299e3cdd0cb0d00c060fb5df4e3cR1449-R1453)

* Added a regression test `RepeatedBoot_DoesNotDuplicatePropertyComment` to verify that repeated configuration boots do not duplicate property comments in the output file. (`tests/Nalix.Environment.Tests/Configuration/IniConfigTests.cs`)

**SDK reconnect behavior clarification:**

* Added a code comment explaining that `OnDisconnected` fires for both unexpected and explicit disconnects, which can inadvertently trigger reconnect attempts if `AutoReconnectEnabled` is on. Suggests that a signal for intentional disconnects should be added if this becomes a common usage pattern. (`src/Nalix.SDK/Transport/Internal/ReconnectSupervisor.cs`)