### PR TITLE
fix(sdk): improve session reconnect logic and sequence reset

### DIFF
--- a/src/Nalix.SDK/Transport/TcpSession.cs
+++ b/src/Nalix.SDK/Transport/TcpSession.cs
@@ -30,6 +30,7 @@ public class TcpSession : TransportSession
 #pragma warning disable CA2213 // Disposed through Interlocked.Exchange locals inside DisconnectInternalAsync/Dispose(bool).
     private Socket? _socket;
     private CancellationTokenSource? _loopCts;
+    private Task? _loopTask;
 #pragma warning restore CA2213
     private int _disposed;
 
@@ -108,11 +109,12 @@ public class TcpSession : TransportSession
             string effectiveHost = string.IsNullOrWhiteSpace(host) ? this.Options.Address : host;
             ushort effectivePort = port ?? this.Options.Port;
 
-            // Ensure single connection at a time
-            if (this.IsConnected)
+            if (_socket is not null || _loopCts is not null || _loopTask is not null)
             {
-                await this.DisconnectInternalAsync().ConfigureAwait(false);
+                await this.DisconnectInternalAsync(waitForLoop: true).ConfigureAwait(false);
             }
+
+            this.ResetSequenceCounters();
 
             // Initialize socket with NoDelay to reduce latency
             _socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp) { NoDelay = this.Options.NoDelay };
@@ -135,7 +137,7 @@ public class TcpSession : TransportSession
             // Start background worker for reading frames
             _loopCts = new CancellationTokenSource();
 
-            _ = Task.Factory.StartNew(() => _reader.ReceiveLoopAsync(_loopCts.Token),
+            _loopTask = Task.Factory.StartNew(() => _reader.ReceiveLoopAsync(_loopCts.Token),
                 _loopCts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
@@ -172,11 +174,12 @@ public class TcpSession : TransportSession
             string effectiveHost = string.IsNullOrWhiteSpace(host) ? this.Options.Address : host;
             ushort effectivePort = port ?? this.Options.Port;
 
-            // Ensure single connection at a time
-            if (this.IsConnected)
+            if (_socket is not null || _loopCts is not null || _loopTask is not null)
             {
-                await this.DisconnectInternalAsync().ConfigureAwait(false);
+                await this.DisconnectInternalAsync(waitForLoop: true).ConfigureAwait(false);
             }
+
+            this.ResetSequenceCounters();
 
             // Initialize socket with NoDelay to reduce latency
             _socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp) { NoDelay = this.Options.NoDelay };
@@ -202,12 +205,12 @@ public class TcpSession : TransportSession
             // Start background worker for reading frames
             _loopCts = new CancellationTokenSource();
 
-            _ = Task.Factory.StartNew(() => _reader.ReceiveLoopAsync(_loopCts.Token),
+            _loopTask = Task.Factory.StartNew(() => _reader.ReceiveLoopAsync(_loopCts.Token),
                 _loopCts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
-            await this.DisconnectInternalAsync().ConfigureAwait(false);
+            await this.DisconnectInternalAsync(waitForLoop: true).ConfigureAwait(false);
             this.OnError?.Invoke(this, ex);
             throw new NetworkException($"Connection failed: {ex.Message}", ex);
         }
@@ -238,9 +241,10 @@ public class TcpSession : TransportSession
         }
     }
 
-    private Task DisconnectInternalAsync()
+    private async Task DisconnectInternalAsync(bool waitForLoop = false)
     {
         CancellationTokenSource? loopCts = Interlocked.Exchange(ref _loopCts, null);
+        Task? loopTask = Interlocked.Exchange(ref _loopTask, null);
         Socket? socket = Interlocked.Exchange(ref _socket, null);
 
         try
@@ -289,7 +293,20 @@ public class TcpSession : TransportSession
             this.OnDisconnected?.Invoke(this, new NetworkException("The TCP session was disconnected."));
         }
 
-        return Task.CompletedTask;
+        if (waitForLoop && loopTask is { IsCompleted: false })
+        {
+            try
+            {
+                await loopTask.ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
+            {
+                if (Volatile.Read(ref _disposed) == 0)
+                {
+                    this.OnError?.Invoke(this, ex);
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/src/Nalix.SDK/Transport/UdpSession.cs
+++ b/src/Nalix.SDK/Transport/UdpSession.cs
@@ -42,10 +42,12 @@ public class UdpSession : TransportSession
     // Low-level components for reading and sending datagrams
     private readonly UdpFrameSender _sender;
     private readonly UdpFrameReader _reader;
+    private readonly SemaphoreSlim _connectionLock = new(1, 1);
 
     private Socket? _socket;
     private IPEndPoint? _remoteEndPoint;
     private CancellationTokenSource? _loopCts;
+    private Task? _loopTask;
     private int _disposed;
 
     #endregion Fields
@@ -127,16 +129,20 @@ public class UdpSession : TransportSession
             PacketRegistry.Build();
         }
 
-        string effectiveHost = string.IsNullOrWhiteSpace(host) ? this.Options.Address : host;
-        ushort effectivePort = port ?? this.Options.Port;
-
-        if (this.IsConnected)
-        {
-            await this.DisconnectInternalAsync().ConfigureAwait(false);
-        }
+        await _connectionLock.WaitAsync(ct).ConfigureAwait(false);
 
         try
         {
+            string effectiveHost = string.IsNullOrWhiteSpace(host) ? this.Options.Address : host;
+            ushort effectivePort = port ?? this.Options.Port;
+
+            if (_socket is not null || _loopCts is not null || _loopTask is not null)
+            {
+                await this.DisconnectInternalAsync(waitForLoop: true).ConfigureAwait(false);
+            }
+
+            this.ResetSequenceCounters();
+
             // Resolve the remote endpoint
             IPAddress[] addresses = await Dns.GetHostAddressesAsync(effectiveHost, ct).ConfigureAwait(false);
             if (addresses.Length == 0)
@@ -175,35 +181,48 @@ public class UdpSession : TransportSession
             _loopCts = new CancellationTokenSource();
 
             // Start background receive loop
-            _ = Task.Factory.StartNew(() => _reader.ReceiveLoopAsync(_loopCts.Token),
+            _loopTask = Task.Factory.StartNew(() => _reader.ReceiveLoopAsync(_loopCts.Token),
                 _loopCts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
 
             this.OnConnected?.Invoke(this, EventArgs.Empty);
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
-            await this.DisconnectInternalAsync().ConfigureAwait(false);
+            await this.DisconnectInternalAsync(waitForLoop: true).ConfigureAwait(false);
             this.OnError?.Invoke(this, ex);
             throw new NetworkException($"UDP Connection failed: {ex.Message}", ex);
+        }
+        finally
+        {
+            _ = _connectionLock.Release();
         }
     }
 
     /// <inheritdoc/>
-    public override Task DisconnectAsync()
+    public override async Task DisconnectAsync()
     {
         if (Volatile.Read(ref _disposed) == 1)
         {
-            return Task.CompletedTask;
+            return;
         }
 
         this.MarkIntentionalDisconnect();
 
-        return this.DisconnectInternalAsync();
+        await _connectionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await this.DisconnectInternalAsync(waitForLoop: true).ConfigureAwait(false);
+        }
+        finally
+        {
+            _ = _connectionLock.Release();
+        }
     }
 
-    private async Task DisconnectInternalAsync()
+    private async Task DisconnectInternalAsync(bool waitForLoop = false)
     {
         CancellationTokenSource? cts = Interlocked.Exchange(ref _loopCts, null);
+        Task? loopTask = Interlocked.Exchange(ref _loopTask, null);
         Socket? socket = Interlocked.Exchange(ref _socket, null);
 
         try
@@ -224,6 +243,21 @@ public class UdpSession : TransportSession
         }
 
         cts?.Dispose();
+
+        if (waitForLoop && loopTask is { IsCompleted: false })
+        {
+            try
+            {
+                await loopTask.ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
+            {
+                if (Volatile.Read(ref _disposed) == 0)
+                {
+                    this.OnError?.Invoke(this, ex);
+                }
+            }
+        }
     }
 
     /// <inheritdoc/>
@@ -269,6 +303,7 @@ public class UdpSession : TransportSession
         _ = this.DisconnectInternalAsync();
         _sender.Dispose();
         _reader.Dispose();
+        _connectionLock.Dispose();
         _socket?.Dispose();
         _loopCts?.Dispose();
     }

--- a/src/Nalix.SDK/Transport/WebSocketSession.cs
+++ b/src/Nalix.SDK/Transport/WebSocketSession.cs
@@ -30,6 +30,7 @@ public class WebSocketSession : TransportSession
 #pragma warning disable CA2213
     private ClientWebSocket? _socket;
     private CancellationTokenSource? _loopCts;
+    private Task? _loopTask;
 #pragma warning restore CA2213
 
     private int _disposed;
@@ -110,10 +111,12 @@ public class WebSocketSession : TransportSession
             string effectiveHost = string.IsNullOrWhiteSpace(host) ? this.Options.Address : host;
             ushort effectivePort = port ?? this.Options.Port;
 
-            if (this.IsConnected)
+            if (_socket is not null || _loopCts is not null || _loopTask is not null)
             {
-                await this.DisconnectInternalAsync().ConfigureAwait(false);
+                await this.DisconnectInternalAsync(waitForLoop: true).ConfigureAwait(false);
             }
+
+            this.ResetSequenceCounters();
 
             _socket = new ClientWebSocket();
 
@@ -141,11 +144,11 @@ public class WebSocketSession : TransportSession
             // LongRunning + TaskScheduler.Default deadlocks in single-threaded
             // runtimes (Blazor WASM). The async loop yields correctly via
             // ConfigureAwait(false) on both desktop and WASM.
-            _ = _reader.ReceiveLoopAsync(_loopCts.Token);
+            _loopTask = _reader.ReceiveLoopAsync(_loopCts.Token);
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
-            await this.DisconnectInternalAsync().ConfigureAwait(false);
+            await this.DisconnectInternalAsync(waitForLoop: true).ConfigureAwait(false);
             this.OnError?.Invoke(this, ex);
             throw new NetworkException($"WebSocket Connection failed: {ex.Message}", ex);
         }
@@ -176,9 +179,10 @@ public class WebSocketSession : TransportSession
         }
     }
 
-    private async Task DisconnectInternalAsync()
+    private async Task DisconnectInternalAsync(bool waitForLoop = false)
     {
         CancellationTokenSource? loopCts = Interlocked.Exchange(ref _loopCts, null);
+        Task? loopTask = Interlocked.Exchange(ref _loopTask, null);
         ClientWebSocket? socket = Interlocked.Exchange(ref _socket, null);
 
         try
@@ -219,6 +223,21 @@ public class WebSocketSession : TransportSession
 
             socket.Dispose();
             this.OnDisconnected?.Invoke(this, new NetworkException("The WebSocket session was disconnected."));
+        }
+
+        if (waitForLoop && loopTask is { IsCompleted: false })
+        {
+            try
+            {
+                await loopTask.ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
+            {
+                if (Volatile.Read(ref _disposed) == 0)
+                {
+                    this.OnError?.Invoke(this, ex);
+                }
+            }
         }
     }
 

--- a/tests/Nalix.SDK.Tests/TransportReconnectSequenceTests.cs
+++ b/tests/Nalix.SDK.Tests/TransportReconnectSequenceTests.cs
@@ -1,0 +1,124 @@
+#if DEBUG
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Threading.Tasks;
+using Nalix.Abstractions;
+using Nalix.Abstractions.Concurrency;
+using Nalix.Abstractions.Networking;
+using Nalix.Environment.Configuration;
+using Nalix.Environment.Sequencing;
+using Nalix.Network.Connections;
+using Nalix.Network.Listeners.Web;
+using Nalix.Network.Options;
+using Nalix.Network.Protocols;
+using Nalix.SDK.Options;
+using Nalix.SDK.Transport;
+
+namespace Nalix.SDK.Tests;
+
+[Collection("RealServerTests")]
+public sealed class TransportReconnectSequenceTests : IDisposable
+{
+    [Fact]
+    public async Task TcpSession_ConnectAsync_AfterStaleSocket_ResetsSendSequence()
+    {
+        int port = TestUtils.GetFreePort();
+        TcpListener listener = new(IPAddress.Loopback, port);
+        listener.Start();
+
+        try
+        {
+            using TcpSession session = new(new TransportOptions { Address = "127.0.0.1", Port = (ushort)port });
+
+            await session.SendAsync(new byte[] { 1 }, encrypt: true);
+            Assert.Equal(1u, CurrentSendSequence(session));
+
+            Task<Socket> acceptTask = listener.AcceptSocketAsync();
+            await session.ConnectAsync();
+            using Socket accepted = await acceptTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(0u, CurrentSendSequence(session));
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task WebSocketSession_ConnectAsync_AfterStaleSocket_ResetsSendSequence()
+    {
+        ushort port = (ushort)TestUtils.GetFreePort();
+        ConfigurationManager.Instance.Get<NetworkWebSocketOptions>().Host = "127.0.0.1";
+
+        using IConnectionHub hub = new ConnectionHub();
+        IConnectionGuard guard = Nalix.Framework.Injection.InstanceManager.Instance.GetOrCreateInstance<Nalix.Network.RateLimiting.ConnectionGuard>();
+        using TestWebSocketListener server = new(port, "/ws/", new NoOpProtocol(), hub, guard);
+        server.Activate();
+        await Task.Delay(500);
+
+        using WebSocketSession session = new(
+            new TransportOptions { Address = "127.0.0.1", Port = port },
+            new WebSocketTransportOptions { Path = "/ws/" });
+
+        await session.SendAsync(new byte[] { 1 }, encrypt: true);
+        Assert.Equal(1u, CurrentSendSequence(session));
+
+        await session.ConnectAsync();
+
+        Assert.Equal(0u, CurrentSendSequence(session));
+        server.Deactivate();
+    }
+
+    [Fact]
+    public async Task UdpSession_ConnectAsync_AfterStaleSocket_ResetsSendSequence()
+    {
+        using UdpSession session = new(new TransportOptions
+        {
+            Address = "127.0.0.1",
+            Port = (ushort)TestUtils.GetFreePort()
+        });
+
+        await session.SendAsync(new byte[] { 1 }, encrypt: true);
+        Assert.Equal(1u, CurrentSendSequence(session));
+
+        await session.ConnectAsync();
+
+        Assert.Equal(0u, CurrentSendSequence(session));
+    }
+
+    public void Dispose() => Nalix.Framework.Injection.InstanceManager.Instance.Clear(dispose: false);
+
+    private static uint CurrentSendSequence(object session)
+    {
+        object sender = session.GetType().GetField("_sender", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(session)!;
+        return ((SequenceCounter)sender.GetType().GetProperty("Sequence", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(sender)!).Current();
+    }
+
+    private sealed class TestWebSocketListener(ushort port, string path, IProtocol protocol, IConnectionHub hub, IConnectionGuard guard)
+        : WebSocketListenerBase(port, path, protocol, hub, guard);
+
+    [Nalix.Abstractions.Injection.Injectable]
+    public sealed class NoOpProtocol : Protocol
+    {
+        private sealed class NoOpFrameProcessor : IFrameProcessor
+        {
+            public void ProcessFrame(object? sender, IConnectionEventArgs args) { }
+        }
+
+        private sealed class NoOpOpCodeExtractor : Nalix.Abstractions.Networking.Protocols.IOpCodeExtractor
+        {
+            public ushort Extract(ReadOnlySpan<byte> payload) => 0;
+        }
+
+        public override IFrameProcessor FrameProcessor { get; } = new NoOpFrameProcessor();
+        public override Nalix.Abstractions.Networking.Protocols.IOpCodeExtractor OpCodeExtractor { get; } = new NoOpOpCodeExtractor();
+
+        public NoOpProtocol() => this.SetConnectionAcceptance(true);
+
+        public override void ProcessMessage(object? sender, IConnectionEventArgs args) { }
+    }
+}
+#endif


### PR DESCRIPTION
Enhance TcpSession, UdpSession, and WebSocketSession to properly clean up stale sockets and background tasks before reconnecting. Add _loopTask tracking, serialize connect/disconnect with SemaphoreSlim, and reset sequence counters on reconnect. Update Dispose methods for new fields. Add TransportReconnectSequenceTests to verify sequence reset after reconnect.