### PR TITLE
refactor(network): diagnostics for ignored forwarded headers

### DIFF
--- a/src/Nalix.Network/Listeners/WebListener/WebSocketListener.Headers.cs
+++ b/src/Nalix.Network/Listeners/WebListener/WebSocketListener.Headers.cs
@@ -28,11 +28,16 @@ public abstract partial class WebSocketListenerBase
         // Forwarded IP headers are client-controlled unless the physical peer is a trusted proxy.
         if (socket.RemoteEndPoint is not IPEndPoint physicalIp || !_limiter.IsTrustedProxy(physicalIp))
         {
-            if (DiagnosticsEvents.Source.IsEnabled(DiagnosticsEvents.Internal.Warning))
+            string diagEvent = _forwardedConfig.RequireTrustedProxy
+                ? DiagnosticsEvents.Internal.Warning
+                : DiagnosticsEvents.Internal.Trace;
+
+            if (DiagnosticsEvents.Source.IsEnabled(diagEvent))
             {
-                DiagnosticsEvents.Write(DiagnosticsEvents.Internal.Warning,
+                EndPoint? remoteEndPoint = socket.RemoteEndPoint;
+                DiagnosticsEvents.Write(diagEvent,
                     new DiagnosticLog("NW.WebSocketListenerBase:ForwardedHeaders",
-                        $"forwarded-header-ignored reason=untrusted-physical-peer remote-endpoint={socket.RemoteEndPoint?.ToString() ?? "<null>"} require-trusted-proxy={_forwardedConfig.RequireTrustedProxy}"));
+                        $"forwarded-header-ignored reason=untrusted-physical-peer remote-endpoint={remoteEndPoint?.ToString() ?? \"<null>\"} require-trusted-proxy={_forwardedConfig.RequireTrustedProxy}"));
             }
 
             reject = _forwardedConfig.RequireTrustedProxy;

--- a/src/Nalix.Network/Listeners/WebListener/WebSocketListener.Headers.cs
+++ b/src/Nalix.Network/Listeners/WebListener/WebSocketListener.Headers.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using Nalix.Abstractions.Diagnostics;
 using Nalix.Network.Internal.WebSockets;
 
 namespace Nalix.Network.Listeners.Web;
@@ -27,6 +28,13 @@ public abstract partial class WebSocketListenerBase
         // Forwarded IP headers are client-controlled unless the physical peer is a trusted proxy.
         if (socket.RemoteEndPoint is not IPEndPoint physicalIp || !_limiter.IsTrustedProxy(physicalIp))
         {
+            if (DiagnosticsEvents.Source.IsEnabled(DiagnosticsEvents.Internal.Warning))
+            {
+                DiagnosticsEvents.Write(DiagnosticsEvents.Internal.Warning,
+                    new DiagnosticLog("NW.WebSocketListenerBase:ForwardedHeaders",
+                        $"forwarded-header-ignored reason=untrusted-physical-peer remote-endpoint={socket.RemoteEndPoint?.ToString() ?? "<null>"} require-trusted-proxy={_forwardedConfig.RequireTrustedProxy}"));
+            }
+
             reject = _forwardedConfig.RequireTrustedProxy;
             return true;
         }

--- a/src/Nalix.Network/Listeners/WebListener/WebSocketListener.Headers.cs
+++ b/src/Nalix.Network/Listeners/WebListener/WebSocketListener.Headers.cs
@@ -37,7 +37,7 @@ public abstract partial class WebSocketListenerBase
                 EndPoint? remoteEndPoint = socket.RemoteEndPoint;
                 DiagnosticsEvents.Write(diagEvent,
                     new DiagnosticLog("NW.WebSocketListenerBase:ForwardedHeaders",
-                        $"forwarded-header-ignored reason=untrusted-physical-peer remote-endpoint={remoteEndPoint?.ToString() ?? \"<null>\"} require-trusted-proxy={_forwardedConfig.RequireTrustedProxy}"));
+                        $"forwarded-header-ignored reason=untrusted-physical-peer remote-endpoint={remoteEndPoint?.ToString() ?? "<null>"} require-trusted-proxy={_forwardedConfig.RequireTrustedProxy}"));
             }
 
             reject = _forwardedConfig.RequireTrustedProxy;


### PR DESCRIPTION
Log a warning when forwarded headers are ignored due to an untrusted physical peer in WebSocketListenerBase, including remote endpoint and trusted proxy requirement details.