### PR TITLE
fix(analyzers): surface diagnostic when SymbolSet.Create fails silently

### DIFF
--- a/analyzers/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.SymbolSet.cs
+++ b/analyzers/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.SymbolSet.cs
@@ -156,7 +156,7 @@ public sealed partial class NalixUsageAnalyzer
         public INamedTypeSymbol? RpcStreamType { get; }
         public int PacketHeaderRegionOffset { get; }
 
-        public static SymbolSet? Create(Compilation compilation)
+        public static SymbolSet? Create(Compilation compilation, out string? missingSymbol)
         {
             INamedTypeSymbol? packetOpcodeAttribute = compilation.GetTypeByMetadataName("Nalix.Abstractions.Networking.Packets.PacketOpcodeAttribute");
             INamedTypeSymbol? controllerAttribute = compilation.GetTypeByMetadataName("Nalix.Abstractions.Networking.Packets.PacketHandlerAttribute");
@@ -221,10 +221,31 @@ public sealed partial class NalixUsageAnalyzer
                 }
             }
 
-            if (packetOpcodeAttribute is null || controllerAttribute is null || packetInterface is null || packetBaseType is null)
+            if (packetOpcodeAttribute is null)
             {
+                missingSymbol = "Nalix.Abstractions.Networking.Packets.PacketOpcodeAttribute";
                 return null;
             }
+
+            if (controllerAttribute is null)
+            {
+                missingSymbol = "Nalix.Abstractions.Networking.Packets.PacketHandlerAttribute";
+                return null;
+            }
+
+            if (packetInterface is null)
+            {
+                missingSymbol = "Nalix.Abstractions.Networking.Packets.IPacket";
+                return null;
+            }
+
+            if (packetBaseType is null)
+            {
+                missingSymbol = "Nalix.Codec.DataFrames.PacketBase`1";
+                return null;
+            }
+
+            missingSymbol = null;
 
             return new SymbolSet(
                     packetOpcodeAttribute,

--- a/analyzers/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.cs
+++ b/analyzers/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.cs
@@ -86,7 +86,8 @@ public sealed partial class NalixUsageAnalyzer : DiagnosticAnalyzer
             DiagnosticDescriptors.RpcServiceInvalidParameters,
             DiagnosticDescriptors.RpcServiceContainsInvalidMembers,
             DiagnosticDescriptors.RpcServiceMissingAttribute,
-            DiagnosticDescriptors.InjectFieldCannotBeReadOnly
+            DiagnosticDescriptors.InjectFieldCannotBeReadOnly,
+            DiagnosticDescriptors.RequiredSymbolUnresolved
         ];
 
     public override void Initialize(AnalysisContext context)
@@ -100,9 +101,14 @@ public sealed partial class NalixUsageAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
         context.RegisterCompilationStartAction(static startContext =>
         {
-            SymbolSet? symbols = SymbolSet.Create(startContext.Compilation);
+            SymbolSet? symbols = SymbolSet.Create(startContext.Compilation, out string? missingSymbol);
             if (symbols is null)
             {
+                startContext.RegisterCompilationEndAction(endContext =>
+                    endContext.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.RequiredSymbolUnresolved,
+                        Location.None,
+                        missingSymbol)));
                 return;
             }
 

--- a/analyzers/Nalix.Analyzers/Diagnostics/DiagnosticDescriptors.cs
+++ b/analyzers/Nalix.Analyzers/Diagnostics/DiagnosticDescriptors.cs
@@ -588,4 +588,14 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "Fields annotated with [Inject] cannot be readonly since they are assigned via reflection or source generation after object instantiation.");
+
+    public static readonly DiagnosticDescriptor RequiredSymbolUnresolved = new(
+        id: "NALIX105",
+        title: "Nalix analyzer disabled: required symbol could not be resolved",
+        messageFormat: "The Nalix analyzer found no diagnostics for this compilation because the required symbol '{0}' could not be resolved. Verify the project references the Nalix package that declares it.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "When a mandatory Nalix symbol cannot be resolved (e.g. a missing package reference), the entire analyzer silently reports nothing. This diagnostic surfaces that condition instead of leaving it indistinguishable from 'no issues found'.",
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
 }


### PR DESCRIPTION
Fixes #349. When a mandatory Nalix symbol (PacketOpcodeAttribute, PacketHandlerAttribute, IPacket, PacketBase<T>) can't be resolved, SymbolSet.Create returned null and the whole analyzer silently registered zero rules — indistinguishable from a clean compilation.

Now Create reports which symbol was missing via an out param, and Initialize reports NALIX105 naming it instead of no-oping.