### PR TITLE
fix(sdk): re-check AutoReconnectEnabled during reconnect loop

### DIFF
--- a/src/Nalix.SDK/Transport/Internal/ReconnectSupervisor.cs
+++ b/src/Nalix.SDK/Transport/Internal/ReconnectSupervisor.cs
@@ -75,6 +75,11 @@ internal sealed class ReconnectSupervisor
 
         while (maxAttempts <= 0 || attempt < maxAttempts)
         {
+            if (!_session.Options.AutoReconnectEnabled)
+            {
+                break;
+            }
+
             attempt++;
 
             int delay = (int)Math.Min(maxDelay, baseDelay * Math.Pow(2, attempt - 1));
@@ -83,6 +88,11 @@ internal sealed class ReconnectSupervisor
             try
             {
                 await Task.Delay(delay).ConfigureAwait(false);
+
+                if (!_session.Options.AutoReconnectEnabled)
+                {
+                    break;
+                }
 
                 ProtocolReason reason = await _session.ConnectWithResumeDetailedAsync().ConfigureAwait(false);
 
@@ -103,7 +113,8 @@ internal sealed class ReconnectSupervisor
         }
 
         _readyTcs = null;
-        _ = tcs.TrySetException(
-            new TimeoutException($"Auto-reconnect gave up after {attempt} attempt(s)."));
+        _ = tcs.TrySetException(_session.Options.AutoReconnectEnabled
+            ? new TimeoutException($"Auto-reconnect gave up after {attempt} attempt(s).")
+            : new OperationCanceledException("Auto-reconnect stopped: AutoReconnectEnabled was disabled."));
     }
 }


### PR DESCRIPTION
## Summary
- `ReconnectLoopAsync` read `AutoReconnectEnabled` once at `OnDisconnected` entry and never again, so clearing the flag after a loop started (the documented way for a client to serialise its own reconnect against the SDK's) had no effect and no way existed to cancel an in-flight loop.
- Because a second connector isn't deduplicated against the first, and `WebSocketSession.ConnectAsync` tears down any socket the session still holds before reconnecting, the second connector could destroy the connection the first had just established.
- Now `ReconnectLoopAsync` re-checks `Options.AutoReconnectEnabled` at the top of each iteration and again after the backoff delay, exiting (and failing the ready-signal with `OperationCanceledException`) as soon as the flag is cleared.

## Test plan
- [x] `dotnet build src/Nalix.sln --configuration Release`
- [x] `dotnet test tests/Nalix.SDK.Tests --configuration Release` (33 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)