### PR TITLE
fix(runtime): enforce PacketEncryption attribute on inbound dispatch

### DIFF
--- a/benchmarks/Nalix.Runtime.Benchmarks/Throttling/PolicyRateLimiterBenchmarks.cs
+++ b/benchmarks/Nalix.Runtime.Benchmarks/Throttling/PolicyRateLimiterBenchmarks.cs
@@ -84,6 +84,7 @@ public class PolicyRateLimiterBenchmarks
     private class BenchmarkPacketContext : IPacketContext<IPacket>
     {
         public bool IsReliable => true;
+        public bool EncryptedOnWire => false;
         public bool SkipOutbound => false;
         public IPacket Packet { get; }
         public IConnection Connection { get; }

--- a/src/Nalix.Abstractions/IBufferLease.cs
+++ b/src/Nalix.Abstractions/IBufferLease.cs
@@ -20,6 +20,14 @@ public interface IBufferLease : IDisposable
     /// </summary>
     bool IsReliable { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether this frame arrived encrypted on the wire.
+    /// Set once by the inbound cipher transforms and preserved across subsequent transforms
+    /// (e.g. decompression) so dispatch can audit the frame's on-wire state even after the
+    /// header's transient <c>ENCRYPTED</c> flag has been cleared.
+    /// </summary>
+    bool EncryptedOnWire { get; set; }
+
     /// <summary>Gets the capacity of the underlying buffer.</summary>
     int Capacity { get; }
 

--- a/src/Nalix.Abstractions/Networking/Packets/IPacketContext.cs
+++ b/src/Nalix.Abstractions/Networking/Packets/IPacketContext.cs
@@ -22,6 +22,13 @@ public interface IPacketContext<TPacket> : IPoolable where TPacket : IPacket
     bool IsReliable { get; }
 
     /// <summary>
+    /// Gets a value indicating whether the inbound frame this packet was deserialized from
+    /// arrived encrypted on the wire. Reflects <see cref="Nalix.Abstractions.IBufferLease.EncryptedOnWire"/>
+    /// as captured at decrypt time, independent of the packet header's transient flags.
+    /// </summary>
+    bool EncryptedOnWire { get; }
+
+    /// <summary>
     /// If true, outbound middlewares will be skipped for this context.
     /// </summary>
     bool SkipOutbound { get; }

--- a/src/Nalix.Codec/Transforms/FrameCipher.cs
+++ b/src/Nalix.Codec/Transforms/FrameCipher.cs
@@ -47,6 +47,15 @@ public static class FrameCipher
         {
             FrameTransformer.Decrypt(src, dest, key, expectedAlgorithm, out seq);
 
+            // The frame authenticated successfully, so it did arrive encrypted on the wire.
+            // Record that on the lease (survives further transforms like decompression)
+            // separately from the header's ENCRYPTED flag, which is transform-internal
+            // bookkeeping and is cleared below.
+            dest.EncryptedOnWire = true;
+
+            ref PacketHeader header = ref dest.Span.AsHeaderRef();
+            header.Flags &= ~PacketFlags.ENCRYPTED;
+
             return dest;
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
@@ -94,8 +103,13 @@ public static class FrameCipher
             return false;
         }
 
-        // The ENCRYPTED flag is intentionally left set — downstream dispatch relies on
-        // it to confirm the frame arrived encrypted on the wire.
+        // Record the on-wire encrypted state on the lease (see DecryptFrame remarks),
+        // then clear the header's transient ENCRYPTED flag.
+        localDest.EncryptedOnWire = true;
+
+        ref PacketHeader header = ref localDest.Span.AsHeaderRef();
+        header.Flags &= ~PacketFlags.ENCRYPTED;
+
         dest = localDest;
         return true;
     }

--- a/src/Nalix.Codec/Transforms/FrameCipher.cs
+++ b/src/Nalix.Codec/Transforms/FrameCipher.cs
@@ -24,7 +24,9 @@ namespace Nalix.Codec.Transforms;
 public static class FrameCipher
 {
     /// <summary>
-    /// Decrypts a framed packet and clears the encrypted flag in the resulting buffer.
+    /// Decrypts a framed packet. The ENCRYPTED flag is intentionally left set on the
+    /// resulting buffer's header so downstream dispatch can still tell the frame arrived
+    /// encrypted on the wire (see <see cref="PacketFlags.ENCRYPTED"/>).
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static IBufferLease DecryptFrame(
@@ -44,9 +46,6 @@ public static class FrameCipher
         try
         {
             FrameTransformer.Decrypt(src, dest, key, expectedAlgorithm, out seq);
-
-            ref PacketHeader header = ref dest.Span.AsHeaderRef();
-            header.Flags &= ~PacketFlags.ENCRYPTED;
 
             return dest;
         }
@@ -95,9 +94,8 @@ public static class FrameCipher
             return false;
         }
 
-        ref PacketHeader header = ref localDest.Span.AsHeaderRef();
-        header.Flags &= ~PacketFlags.ENCRYPTED;
-
+        // The ENCRYPTED flag is intentionally left set — downstream dispatch relies on
+        // it to confirm the frame arrived encrypted on the wire.
         dest = localDest;
         return true;
     }

--- a/src/Nalix.Codec/Transforms/FrameCompression.cs
+++ b/src/Nalix.Codec/Transforms/FrameCompression.cs
@@ -37,6 +37,7 @@ public static class FrameCompression
         IBufferLease dest = BufferLease.Rent(FrameTransformer
                                        .GetDecompressedLength(src.Span[FrameTransformer.Offset..]) + FrameTransformer.Offset);
         dest.IsReliable = src.IsReliable;
+        dest.EncryptedOnWire = src.EncryptedOnWire;
         try
         {
             FrameTransformer.Decompress(src, dest);
@@ -78,6 +79,7 @@ public static class FrameCompression
 
         IBufferLease localDest = BufferLease.Rent(decompressedLength + FrameTransformer.Offset);
         localDest.IsReliable = src.IsReliable;
+        localDest.EncryptedOnWire = src.EncryptedOnWire;
 
         if (!FrameTransformer.TryDecompress(src, localDest))
         {
@@ -108,6 +110,7 @@ public static class FrameCompression
         IBufferLease dest = BufferLease.Rent(FrameTransformer
                                        .GetMaxCompressedSize(src.Length - FrameTransformer.Offset) + FrameTransformer.Offset);
         dest.IsReliable = src.IsReliable;
+        dest.EncryptedOnWire = src.EncryptedOnWire;
 
         try
         {

--- a/src/Nalix.Codec/Transforms/FramePipeline.cs
+++ b/src/Nalix.Codec/Transforms/FramePipeline.cs
@@ -161,6 +161,7 @@ public static class FramePipeline
             // 3. Rent final lease for the fully decompressed packet
             BufferLease finalLease = BufferLease.Rent(FrameTransformer.Offset + decompressedSize);
             finalLease.IsReliable = current.IsReliable;
+            finalLease.EncryptedOnWire = true;
 
             Span<byte> destFull = finalLease.SpanFull;
 
@@ -174,11 +175,11 @@ public static class FramePipeline
             // 5. Copy the header once
             srcSpan[..FrameTransformer.Offset].CopyTo(destFull[..FrameTransformer.Offset]);
 
-            // 6. Clear the COMPRESSED flag from the final header. ENCRYPTED is
-            // intentionally preserved — downstream dispatch relies on it to confirm
-            // the frame arrived encrypted on the wire.
+            // 6. Clear both transient flags from the final header. The on-wire encrypted
+            // state was already recorded on finalLease.EncryptedOnWire above, so dispatch
+            // does not depend on this flag surviving decryption.
             ref PacketHeader header = ref destFull.AsHeaderRef();
-            header.Flags &= ~PacketFlags.COMPRESSED;
+            header.Flags &= ~(PacketFlags.COMPRESSED | PacketFlags.ENCRYPTED);
 
             // 7. Finalize the lease length
             finalLease.CommitLength(FrameTransformer.Offset + finalLen);

--- a/src/Nalix.Codec/Transforms/FramePipeline.cs
+++ b/src/Nalix.Codec/Transforms/FramePipeline.cs
@@ -174,9 +174,11 @@ public static class FramePipeline
             // 5. Copy the header once
             srcSpan[..FrameTransformer.Offset].CopyTo(destFull[..FrameTransformer.Offset]);
 
-            // 6. Clear both ENCRYPTED and COMPRESSED flags from the final header
+            // 6. Clear the COMPRESSED flag from the final header. ENCRYPTED is
+            // intentionally preserved — downstream dispatch relies on it to confirm
+            // the frame arrived encrypted on the wire.
             ref PacketHeader header = ref destFull.AsHeaderRef();
-            header.Flags &= ~(PacketFlags.COMPRESSED | PacketFlags.ENCRYPTED);
+            header.Flags &= ~PacketFlags.COMPRESSED;
 
             // 7. Finalize the lease length
             finalLease.CommitLength(FrameTransformer.Offset + finalLen);

--- a/src/Nalix.Environment/Memory/BufferLease.cs
+++ b/src/Nalix.Environment/Memory/BufferLease.cs
@@ -243,6 +243,7 @@ public sealed class BufferLease : IBufferLease, IPoolable, IPoolRentable
         this.Length = 0;
         this.ZeroOnDispose = false;
         this.IsReliable = false;
+        this.EncryptedOnWire = false;
     }
 
 #if DEBUG
@@ -271,6 +272,9 @@ public sealed class BufferLease : IBufferLease, IPoolable, IPoolRentable
 
     /// <inheritdoc/>
     public bool IsReliable { get; set; }
+
+    /// <inheritdoc/>
+    public bool EncryptedOnWire { get; set; }
 
     /// <summary>
     /// Gets the capacity of the owned slice (from <c>_start</c> to end of the array).

--- a/src/Nalix.Runtime/Dispatching/InlinePacketDispatcher.cs
+++ b/src/Nalix.Runtime/Dispatching/InlinePacketDispatcher.cs
@@ -94,6 +94,7 @@ public sealed class InlinePacketDispatcher
     {
         // 1. Read the packet header directly from the raw span to determine routing
         bool isReliable = lease.IsReliable;
+        bool encryptedOnWire = lease.EncryptedOnWire;
         ushort opcode = connection.PacketClassifier.Extract(lease.Span);
 
         // 2. Resolve the handler using the parsed opcode
@@ -155,7 +156,7 @@ public sealed class InlinePacketDispatcher
              * 2. If it completes synchronously, we can dispose resources immediately.
              * 3. If it's asynchronous, we hand off to AwaitPacketHandlerCompletionAsync.
              */
-            ValueTask pending = this.Options.ExecuteResolvedHandlerAsync(in handler, packet, connection, isReliable, ct);
+            ValueTask pending = this.Options.ExecuteResolvedHandlerAsync(in handler, packet, connection, isReliable, encryptedOnWire, ct);
 
             // Fast-path: handler completed synchronously
             if (pending.IsCompletedSuccessfully)

--- a/src/Nalix.Runtime/Dispatching/Options/PacketDispatchOptions.Execution.cs
+++ b/src/Nalix.Runtime/Dispatching/Options/PacketDispatchOptions.Execution.cs
@@ -84,11 +84,11 @@ public sealed partial class PacketDispatchOptions<TPacket>
     {
         ct.ThrowIfCancellationRequested();
 
-        // Permission check — sync, no allocation.
-        if (!descriptor.CanExecute(context))
+        // Permission / encryption policy check — sync, no allocation.
+        if (!descriptor.CanExecute(context, out ProtocolReason denyReason))
         {
             // Cold path: denied — requires async I/O to send directive.
-            return SendDenyControlAsync(this, descriptor, context);
+            return SendDenyControlAsync(this, descriptor, context, denyReason);
         }
 
         // Handler execution — try sync fast-path.
@@ -115,26 +115,30 @@ public sealed partial class PacketDispatchOptions<TPacket>
 
     private static async ValueTask SendDenyControlAsync(
         PacketDispatchOptions<TPacket> owner, PacketHandler<TPacket> descriptor,
-        PacketContext<TPacket> context)
+        PacketContext<TPacket> context, ProtocolReason reason)
     {
         try
         {
-            // Rate limiting is treated as a protocol failure with a transient retry hint.
+            // Policy denials that can clear up on their own (e.g. rate limiting) get a
+            // transient retry hint; hard policy failures (e.g. missing required
+            // encryption) are not retryable without changing how the client sends.
+            bool transient = reason == ProtocolReason.RATE_LIMITED;
+
             await owner.TrySendControlAsync(
                 context,
                 descriptor.OpCode,
                 controlType: ControlType.FAIL,
-                reason: ProtocolReason.RATE_LIMITED,
-                action: ProtocolAdvice.RETRY,
+                reason: reason,
+                action: transient ? ProtocolAdvice.RETRY : ProtocolAdvice.DO_NOT_RETRY,
                 options: new ControlDirectiveOptions(
-                    Flags: ControlFlags.IS_TRANSIENT,
+                    Flags: transient ? ControlFlags.IS_TRANSIENT : ControlFlags.NONE,
                     SequenceId: context.Packet.Header.SequenceId,
                     Arg0: descriptor.OpCode)).ConfigureAwait(false);
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
             await owner.HandleDispatchExceptionAsync(descriptor, context, ex)
-                      .ConfigureAwait(false);
+                       .ConfigureAwait(false);
         }
     }
 
@@ -170,7 +174,7 @@ public sealed partial class PacketDispatchOptions<TPacket>
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
             await owner.HandleDispatchExceptionAsync(descriptor, context, ex)
-                      .ConfigureAwait(false);
+                       .ConfigureAwait(false);
         }
         finally
         {
@@ -221,7 +225,7 @@ public sealed partial class PacketDispatchOptions<TPacket>
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
             await owner.HandleDispatchExceptionAsync(descriptor, context, ex)
-                      .ConfigureAwait(false);
+                       .ConfigureAwait(false);
         }
         finally
         {

--- a/src/Nalix.Runtime/Dispatching/Options/PacketDispatchOptions.PublicMethods.cs
+++ b/src/Nalix.Runtime/Dispatching/Options/PacketDispatchOptions.PublicMethods.cs
@@ -312,6 +312,7 @@ public sealed partial class PacketDispatchOptions<TPacket>
     /// <param name="packet">Incoming packet.</param>
     /// <param name="connection">Source connection.</param>
     /// <param name="reliable">Indicates whether the packet was received via a reliable transport.</param>
+    /// <param name="encryptedOnWire">Indicates whether the inbound frame arrived encrypted on the wire.</param>
     /// <param name="token">Cancellation token for dispatch.</param>
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     internal ValueTask ExecuteResolvedHandlerAsync(
@@ -319,6 +320,7 @@ public sealed partial class PacketDispatchOptions<TPacket>
         TPacket packet,
         IConnection connection,
         bool reliable,
+        bool encryptedOnWire,
         CancellationToken token = default)
     {
         PacketContext<TPacket> context = _objectPool.Get<PacketContext<TPacket>>();
@@ -330,6 +332,7 @@ public sealed partial class PacketDispatchOptions<TPacket>
                 connection: connection,
                 descriptor: descriptor.Metadata,
                 reliable: reliable,
+                encryptedOnWire: encryptedOnWire,
                 ownsPacket: true, token: token);
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))

--- a/src/Nalix.Runtime/Dispatching/PacketContext.cs
+++ b/src/Nalix.Runtime/Dispatching/PacketContext.cs
@@ -46,6 +46,15 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
     }
 
     /// <inheritdoc/>
+    public bool EncryptedOnWire
+    {
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        get;
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private set;
+    }
+
+    /// <inheritdoc/>
     public bool SkipOutbound
     {
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
@@ -121,6 +130,7 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
         this.Sender = new PacketSender();
         this.Packet = default!;
         this.IsReliable = false;
+        this.EncryptedOnWire = false;
         this.Connection = default!;
         this.Attributes = default!;
     }
@@ -136,6 +146,7 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
     /// <param name="connection">The connection associated with the packet.</param>
     /// <param name="descriptor">The metadata describing the packet.</param>
     /// <param name="reliable">Whether the packet was received over a reliable transport.</param>
+    /// <param name="encryptedOnWire">Whether the inbound frame arrived encrypted on the wire.</param>
     /// <param name="ownsPacket">Indicates whether the context owns the packet and is responsible for its disposal.</param>
     /// <param name="token">The cancellation token for the context.</param>
     /// <remarks>
@@ -144,7 +155,9 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
     /// </remarks>
     /// <exception cref="InternalErrorException"></exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void Initialize(TPacket packet, IConnection connection, PacketMetadata descriptor, bool reliable, bool ownsPacket = true, CancellationToken token = default)
+    internal void Initialize(
+        TPacket packet, IConnection connection, PacketMetadata descriptor,
+        bool reliable, bool encryptedOnWire, bool ownsPacket = true, CancellationToken token = default)
     {
         _ = Interlocked.Exchange(ref _state, (int)PacketContextState.InUse);
 
@@ -153,6 +166,7 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
 
         this.Packet = packet;
         this.IsReliable = reliable;
+        this.EncryptedOnWire = encryptedOnWire;
         this.Connection = connection;
         this.Attributes = descriptor;
         this.CancellationToken = token;
@@ -205,6 +219,7 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
 
             this.Packet = default!;
             this.IsReliable = false;
+            this.EncryptedOnWire = false;
             this.SkipOutbound = false;
             this.Attributes = default!;
             this.Connection = default!;

--- a/src/Nalix.Runtime/Dispatching/PacketContextBridge.cs
+++ b/src/Nalix.Runtime/Dispatching/PacketContextBridge.cs
@@ -37,6 +37,7 @@ public static class PacketContextBridge
             baseContext.Connection,
             baseContext.Attributes,
             baseContext.IsReliable,
+            baseContext.EncryptedOnWire,
             ownsPacket: false,
             baseContext.CancellationToken);
 

--- a/src/Nalix.Runtime/Dispatching/PacketDispatchChannel.cs
+++ b/src/Nalix.Runtime/Dispatching/PacketDispatchChannel.cs
@@ -580,12 +580,14 @@ public sealed class PacketDispatchChannel
         ushort opcode;
         IPacket packet;
         bool isReliable;
+        bool encryptedOnWire;
         PacketHandler<IPacket> handler;
 
         try
         {
             // 1. Read the packet header directly from the raw span to determine routing
             isReliable = lease.IsReliable;
+            encryptedOnWire = lease.EncryptedOnWire;
             opcode = connection.PacketClassifier.Extract(lease.Span);
 
             // 2. Resolve the handler using the parsed opcode
@@ -658,7 +660,7 @@ public sealed class PacketDispatchChannel
              * 2. If it completes synchronously, we can dispose resources immediately.
              * 3. If it's asynchronous, we hand off to AwaitPacketHandlerCompletionAsync.
              */
-            ValueTask pending = this.Options.ExecuteResolvedHandlerAsync(in handler, packet, connection, isReliable, ct);
+            ValueTask pending = this.Options.ExecuteResolvedHandlerAsync(in handler, packet, connection, isReliable, encryptedOnWire, ct);
 
             // Fast-path: handler completed synchronously
             if (pending.IsCompletedSuccessfully)

--- a/src/Nalix.Runtime/Internal/Compilation/PacketHandler.cs
+++ b/src/Nalix.Runtime/Internal/Compilation/PacketHandler.cs
@@ -132,13 +132,13 @@ internal readonly struct PacketHandler<TPacket>(
 
         // Enforce declared encryption requirement: a handler marked
         // [PacketEncryption(true)] must not execute for a frame that
-        // did not arrive encrypted on the wire. The ENCRYPTED flag on the
-        // deserialized header still reflects the frame's on-wire state here
-        // because the inbound cipher transforms preserve it (see
-        // FrameCipher.DecryptFrame / TryDecryptFrame and
-        // FramePipeline.TryProcessInboundFused).
-        if (Metadata.Encryption is { IsEncrypted: true } &&
-            (context.Packet.Header.Flags & PacketFlags.ENCRYPTED) == 0)
+        // did not arrive encrypted on the wire. The header's ENCRYPTED flag
+        // is transient transform-internal bookkeeping and is cleared once the
+        // inbound cipher transforms finish decrypting, so it cannot be used
+        // here. PacketContext.EncryptedOnWire is a dedicated signal captured
+        // once at decrypt time (see FrameCipher.DecryptFrame / TryDecryptFrame)
+        // and propagated across subsequent transforms (e.g. decompression).
+        if (Metadata.Encryption is { IsEncrypted: true } && !context.EncryptedOnWire)
         {
             denyReason = ProtocolReason.FORBIDDEN;
             return false;

--- a/src/Nalix.Runtime/Internal/Compilation/PacketHandler.cs
+++ b/src/Nalix.Runtime/Internal/Compilation/PacketHandler.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Nalix.Abstractions.Networking.Packets;
+using Nalix.Abstractions.Networking.Protocols;
 using Nalix.Runtime.Dispatching;
 
 #if DEBUG
@@ -103,6 +104,10 @@ internal readonly struct PacketHandler<TPacket>(
     /// Determines whether this handler can be executed for the specified packet context.
     /// </summary>
     /// <param name="context">The packet context to validate for execution.</param>
+    /// <param name="denyReason">
+    /// When this method returns <see langword="false"/>, the protocol reason that should be
+    /// reported back to the caller for the denial.
+    /// </param>
     /// <returns><see langword="true"/> if the handler can be executed; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
     /// This method can be extended to implement validation logic such as:
@@ -113,7 +118,7 @@ internal readonly struct PacketHandler<TPacket>(
     /// </list>
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    public bool CanExecute(PacketContext<TPacket> context)
+    public bool CanExecute(PacketContext<TPacket> context, out ProtocolReason denyReason)
     {
         // SEC-77: Enforce permission policy by default on the hot path.
         // Middleware is still recommended for logging and more complex policies,
@@ -121,18 +126,25 @@ internal readonly struct PacketHandler<TPacket>(
         if (Metadata.Permission is { } permission &&
             permission.Level > context.Connection.Level)
         {
+            denyReason = ProtocolReason.RATE_LIMITED;
             return false;
         }
 
         // Enforce declared encryption requirement: a handler marked
         // [PacketEncryption(true)] must not execute for a frame that
-        // arrived without the ENCRYPTED flag set.
+        // did not arrive encrypted on the wire. The ENCRYPTED flag on the
+        // deserialized header still reflects the frame's on-wire state here
+        // because the inbound cipher transforms preserve it (see
+        // FrameCipher.DecryptFrame / TryDecryptFrame and
+        // FramePipeline.TryProcessInboundFused).
         if (Metadata.Encryption is { IsEncrypted: true } &&
             (context.Packet.Header.Flags & PacketFlags.ENCRYPTED) == 0)
         {
+            denyReason = ProtocolReason.FORBIDDEN;
             return false;
         }
 
+        denyReason = ProtocolReason.NONE;
         return true;
     }
 

--- a/src/Nalix.Runtime/Internal/Compilation/PacketHandler.cs
+++ b/src/Nalix.Runtime/Internal/Compilation/PacketHandler.cs
@@ -124,6 +124,15 @@ internal readonly struct PacketHandler<TPacket>(
             return false;
         }
 
+        // Enforce declared encryption requirement: a handler marked
+        // [PacketEncryption(true)] must not execute for a frame that
+        // arrived without the ENCRYPTED flag set.
+        if (Metadata.Encryption is { IsEncrypted: true } &&
+            (context.Packet.Header.Flags & PacketFlags.ENCRYPTED) == 0)
+        {
+            return false;
+        }
+
         return true;
     }
 

--- a/tests/Nalix.Codec.Tests/DataFrames/DataFramesSignalAndTransformEdgeTests.cs
+++ b/tests/Nalix.Codec.Tests/DataFrames/DataFramesSignalAndTransformEdgeTests.cs
@@ -112,7 +112,7 @@ public sealed class DataFramesSignalAndTransformEdgeTests
     }
 
     [Fact]
-    public void FrameCipherDecryptPreservesEncryptedFlagAndOtherFlags()
+    public void FrameCipherDecryptRemovesOnlyEncryptedFlagAndKeepsOtherFlags()
     {
         byte[] key = new byte[32];
         for (int i = 0; i < key.Length; i++)
@@ -132,7 +132,8 @@ public sealed class DataFramesSignalAndTransformEdgeTests
 
         PacketFlags flags = decrypted.Span.AsHeaderRef().Flags;
         Assert.True(flags.HasFlag(PacketFlags.COMPRESSED));
-        Assert.True(flags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.False(flags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.True(decrypted.EncryptedOnWire);
     }
 
     [Fact]

--- a/tests/Nalix.Codec.Tests/DataFrames/DataFramesSignalAndTransformEdgeTests.cs
+++ b/tests/Nalix.Codec.Tests/DataFrames/DataFramesSignalAndTransformEdgeTests.cs
@@ -112,7 +112,7 @@ public sealed class DataFramesSignalAndTransformEdgeTests
     }
 
     [Fact]
-    public void FrameCipherDecryptRemovesOnlyEncryptedFlagAndKeepsOtherFlags()
+    public void FrameCipherDecryptPreservesEncryptedFlagAndOtherFlags()
     {
         byte[] key = new byte[32];
         for (int i = 0; i < key.Length; i++)
@@ -132,7 +132,7 @@ public sealed class DataFramesSignalAndTransformEdgeTests
 
         PacketFlags flags = decrypted.Span.AsHeaderRef().Flags;
         Assert.True(flags.HasFlag(PacketFlags.COMPRESSED));
-        Assert.False(flags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.True(flags.HasFlag(PacketFlags.ENCRYPTED));
     }
 
     [Fact]

--- a/tests/Nalix.Codec.Tests/DataFrames/PacketTransformTests.cs
+++ b/tests/Nalix.Codec.Tests/DataFrames/PacketTransformTests.cs
@@ -46,9 +46,10 @@ public sealed class PacketTransformTests
         // 3. Decrypt
         using IBufferLease decrypted = FrameCipher.DecryptFrame(encrypted, s_testKey, CipherSuiteType.Chacha20Poly1305, out _);
 
-        // ENCRYPTED is intentionally preserved post-decrypt as an on-wire audit signal
-        // (see FrameCipher.DecryptFrame remarks).
-        Assert.True(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
+        // ENCRYPTED is transform-internal bookkeeping and is cleared post-decrypt;
+        // the dedicated EncryptedOnWire signal is the on-wire audit trail instead.
+        Assert.False(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.True(decrypted.EncryptedOnWire);
         Assert.Equal(src.Length, decrypted.Length);
 
         byte[] resultPayload = decrypted.Span[FrameTransformer.Offset..].ToArray();
@@ -72,7 +73,8 @@ public sealed class PacketTransformTests
 
         using IBufferLease decrypted = FrameCipher.DecryptFrame(encrypted, s_testKey, CipherSuiteType.Chacha20Poly1305, out _);
 
-        Assert.True(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.False(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.True(decrypted.EncryptedOnWire);
         Assert.Equal(FrameTransformer.Offset, decrypted.Length);
     }
 
@@ -130,8 +132,9 @@ public sealed class PacketTransformTests
         using IBufferLease decompressed = FrameCompression.DecompressFrame(compressed);
         using IBufferLease decrypted = FrameCipher.DecryptFrame(decompressed, s_testKey, CipherSuiteType.Chacha20Poly1305, out _);
 
-        Assert.True(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.False(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
         Assert.False(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.COMPRESSED));
+        Assert.True(decrypted.EncryptedOnWire);
         Assert.Equal(src.Length, decrypted.Length);
 
         byte[] resultPayload = decrypted.Span[FrameTransformer.Offset..].ToArray();
@@ -176,13 +179,10 @@ public sealed class PacketTransformTests
         PacketFlags restoredFlags = restored.Span.AsHeaderRef().Flags;
         Assert.True(restoredFlags.HasFlag(PacketFlags.NONE));
         Assert.False(restoredFlags.HasFlag(PacketFlags.COMPRESSED));
-        Assert.True(restoredFlags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.False(restoredFlags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.True(restored.EncryptedOnWire);
         Assert.Equal(src.Length, restored.Length);
-        // Compare payload only: the header's ENCRYPTED bit is intentionally preserved
-        // post-decrypt as an on-wire audit signal, so it differs from the plaintext src header.
-        Assert.Equal(
-            src.Span[FrameTransformer.Offset..].ToArray(),
-            restored.Span[FrameTransformer.Offset..].ToArray());
+        Assert.Equal(src.Span.ToArray(), restored.Span.ToArray());
     }
 }
 

--- a/tests/Nalix.Codec.Tests/DataFrames/PacketTransformTests.cs
+++ b/tests/Nalix.Codec.Tests/DataFrames/PacketTransformTests.cs
@@ -46,7 +46,9 @@ public sealed class PacketTransformTests
         // 3. Decrypt
         using IBufferLease decrypted = FrameCipher.DecryptFrame(encrypted, s_testKey, CipherSuiteType.Chacha20Poly1305, out _);
 
-        Assert.False(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
+        // ENCRYPTED is intentionally preserved post-decrypt as an on-wire audit signal
+        // (see FrameCipher.DecryptFrame remarks).
+        Assert.True(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
         Assert.Equal(src.Length, decrypted.Length);
 
         byte[] resultPayload = decrypted.Span[FrameTransformer.Offset..].ToArray();
@@ -70,7 +72,7 @@ public sealed class PacketTransformTests
 
         using IBufferLease decrypted = FrameCipher.DecryptFrame(encrypted, s_testKey, CipherSuiteType.Chacha20Poly1305, out _);
 
-        Assert.False(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.True(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
         Assert.Equal(FrameTransformer.Offset, decrypted.Length);
     }
 
@@ -128,7 +130,7 @@ public sealed class PacketTransformTests
         using IBufferLease decompressed = FrameCompression.DecompressFrame(compressed);
         using IBufferLease decrypted = FrameCipher.DecryptFrame(decompressed, s_testKey, CipherSuiteType.Chacha20Poly1305, out _);
 
-        Assert.False(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.True(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.ENCRYPTED));
         Assert.False(decrypted.Span.AsHeaderRef().Flags.HasFlag(PacketFlags.COMPRESSED));
         Assert.Equal(src.Length, decrypted.Length);
 
@@ -174,9 +176,13 @@ public sealed class PacketTransformTests
         PacketFlags restoredFlags = restored.Span.AsHeaderRef().Flags;
         Assert.True(restoredFlags.HasFlag(PacketFlags.NONE));
         Assert.False(restoredFlags.HasFlag(PacketFlags.COMPRESSED));
-        Assert.False(restoredFlags.HasFlag(PacketFlags.ENCRYPTED));
+        Assert.True(restoredFlags.HasFlag(PacketFlags.ENCRYPTED));
         Assert.Equal(src.Length, restored.Length);
-        Assert.Equal(src.Span.ToArray(), restored.Span.ToArray());
+        // Compare payload only: the header's ENCRYPTED bit is intentionally preserved
+        // post-decrypt as an on-wire audit signal, so it differs from the plaintext src header.
+        Assert.Equal(
+            src.Span[FrameTransformer.Offset..].ToArray(),
+            restored.Span[FrameTransformer.Offset..].ToArray());
     }
 }
 

--- a/tests/Nalix.Runtime.Tests/DispatchChannelTests.cs
+++ b/tests/Nalix.Runtime.Tests/DispatchChannelTests.cs
@@ -568,6 +568,7 @@ public sealed class DispatchChannelTests
 
         public int Length => _buffer.Length;
         public bool IsReliable { get; set; }
+        public bool EncryptedOnWire { get; set; }
         public int Capacity => _buffer.Length;
         public Span<byte> Span => _disposed != 0 ? throw new ObjectDisposedException(nameof(FakeBufferLease)) : _buffer;
         public Span<byte> SpanFull => Span;

--- a/tests/Nalix.Runtime.Tests/PacketHandlerGeneratorBehaviorTests.cs
+++ b/tests/Nalix.Runtime.Tests/PacketHandlerGeneratorBehaviorTests.cs
@@ -50,7 +50,7 @@ public sealed class PacketHandlerGeneratorBehaviorTests
         FakeConnection connection = new();
 
         _ = options.TryResolveHandler(EchoController.VoidOpCode, out PacketHandler<EchoPacket> descriptor);
-        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.VoidOpCode), connection, reliable: true);
+        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.VoidOpCode), connection, reliable: true, encryptedOnWire: false);
 
         controller.VoidInvoked.Should().BeTrue();
         connection.FakeTcp.SentMessages.Should().BeEmpty("a void handler never produces an outbound payload");
@@ -64,7 +64,7 @@ public sealed class PacketHandlerGeneratorBehaviorTests
         FakeConnection connection = new();
 
         _ = options.TryResolveHandler(EchoController.ValueTaskOpCode, out PacketHandler<EchoPacket> descriptor);
-        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.ValueTaskOpCode), connection, reliable: true);
+        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.ValueTaskOpCode), connection, reliable: true, encryptedOnWire: false);
 
         controller.ValueTaskInvoked.Should().BeTrue("the generated invoker must await the ValueTask before returning");
         connection.FakeTcp.SentMessages.Should().BeEmpty();
@@ -78,7 +78,7 @@ public sealed class PacketHandlerGeneratorBehaviorTests
         FakeConnection connection = new();
 
         _ = options.TryResolveHandler(EchoController.TaskOpCode, out PacketHandler<EchoPacket> descriptor);
-        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.TaskOpCode), connection, reliable: true);
+        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.TaskOpCode), connection, reliable: true, encryptedOnWire: false);
 
         controller.TaskInvoked.Should().BeTrue();
         connection.FakeTcp.SentMessages.Should().BeEmpty();
@@ -101,7 +101,7 @@ public sealed class PacketHandlerGeneratorBehaviorTests
         FakeConnection connection = new();
 
         _ = options.TryResolveHandler(EchoController.ValueTaskOfTOpCode, out PacketHandler<EchoPacket> descriptor);
-        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.ValueTaskOfTOpCode), connection, reliable: true);
+        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.ValueTaskOfTOpCode), connection, reliable: true, encryptedOnWire: false);
 
         connection.FakeTcp.SentMessages.Should().NotBeEmpty(
             "a ValueTask<T> handler's result must be awaited and the resulting packet actually sent");
@@ -115,7 +115,7 @@ public sealed class PacketHandlerGeneratorBehaviorTests
         FakeConnection connection = new();
 
         _ = options.TryResolveHandler(EchoController.TaskOfTOpCode, out PacketHandler<EchoPacket> descriptor);
-        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.TaskOfTOpCode), connection, reliable: true);
+        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.TaskOfTOpCode), connection, reliable: true, encryptedOnWire: false);
 
         connection.FakeTcp.SentMessages.Should().NotBeEmpty(
             "a Task<T> handler's result must be awaited and the resulting packet actually sent");
@@ -129,7 +129,7 @@ public sealed class PacketHandlerGeneratorBehaviorTests
         FakeConnection connection = new();
 
         _ = options.TryResolveHandler(EchoController.ContextOpCode, out PacketHandler<EchoPacket> descriptor);
-        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.ContextOpCode), connection, reliable: true);
+        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.ContextOpCode), connection, reliable: true, encryptedOnWire: false);
 
         controller.ContextInvoked.Should().BeTrue();
         connection.FakeTcp.SentMessages.Should().NotBeEmpty(
@@ -144,7 +144,7 @@ public sealed class PacketHandlerGeneratorBehaviorTests
         FakeConnection connection = new();
 
         _ = options.TryResolveHandler(EchoController.ThrowingOpCode, out PacketHandler<EchoPacket> descriptor);
-        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.ThrowingOpCode), connection, reliable: true);
+        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.ThrowingOpCode), connection, reliable: true, encryptedOnWire: false);
 
         connection.FakeTcp.SentMessages.Should().NotBeEmpty(
             "an exception thrown asynchronously inside a generated handler must be converted to a FAIL control, not swallowed silently");

--- a/tests/Nalix.Runtime.Tests/PolicyRateLimiterTests.cs
+++ b/tests/Nalix.Runtime.Tests/PolicyRateLimiterTests.cs
@@ -133,6 +133,7 @@ public sealed class PolicyRateLimiterTests : IDisposable
     private sealed class TestPacketContext(IConnection connection, ushort opCode, PacketRateLimitAttribute? rateLimit) : IPacketContext<IPacket>
     {
         public bool IsReliable => true;
+        public bool EncryptedOnWire => false;
         public bool SkipOutbound => false;
         public IPacket Packet { get; } = new TestPacket(opCode);
         public IConnection Connection { get; } = connection;

--- a/tests/Nalix.Runtime.Tests/RuntimeDispatchAndHandlersTests.cs
+++ b/tests/Nalix.Runtime.Tests/RuntimeDispatchAndHandlersTests.cs
@@ -146,7 +146,7 @@ public sealed class RuntimeDispatchAndHandlersTests
         try
         {
             Func<Task> act = async () => await options.ExecuteResolvedHandlerAsync(
-                descriptor, new TestPacket(), connection, reliable: true).AsTask();
+                descriptor, new TestPacket(), connection, reliable: true, encryptedOnWire: false).AsTask();
 
             await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("sync boom");
         }
@@ -185,7 +185,7 @@ public sealed class RuntimeDispatchAndHandlersTests
         try
         {
             await options.ExecuteResolvedHandlerAsync(
-                descriptor, new TestPacket(), connection, reliable: true).AsTask();
+                descriptor, new TestPacket(), connection, reliable: true, encryptedOnWire: false).AsTask();
 
             observedException.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be("async boom");
             observedOpCode.Should().Be(descriptor.OpCode);
@@ -221,7 +221,7 @@ public sealed class RuntimeDispatchAndHandlersTests
         try
         {
             Func<Task> act = async () => await options.ExecuteResolvedHandlerAsync(
-                descriptor, new TestPacket(), connection, reliable: true, token: cts.Token).AsTask();
+                descriptor, new TestPacket(), connection, reliable: true, encryptedOnWire: false, token: cts.Token).AsTask();
 
             await act.Should().ThrowAsync<OperationCanceledException>();
             invoked.Should().BeFalse("a pre-cancelled token must short-circuit before the handler runs");
@@ -254,7 +254,7 @@ public sealed class RuntimeDispatchAndHandlersTests
         try
         {
             await options.ExecuteResolvedHandlerAsync(
-                descriptor, new TestPacket(), connection, reliable: true).AsTask();
+                descriptor, new TestPacket(), connection, reliable: true, encryptedOnWire: false).AsTask();
 
             connection.FakeTcp.SentMessages.Should().NotBeEmpty(
                 "a handler exceeding its configured timeout must cause a TIMEOUT directive to be sent");
@@ -291,7 +291,7 @@ public sealed class RuntimeDispatchAndHandlersTests
         try
         {
             Func<Task> act = async () => await options.ExecuteResolvedHandlerAsync(
-                descriptor, new TestPacket(), connection, reliable: true, token: outerCts.Token).AsTask();
+                descriptor, new TestPacket(), connection, reliable: true, encryptedOnWire: false, token: outerCts.Token).AsTask();
 
             await act.Should().ThrowAsync<OperationCanceledException>();
             connection.FakeTcp.SentMessages.Should().BeEmpty(
@@ -303,20 +303,86 @@ public sealed class RuntimeDispatchAndHandlersTests
         }
     }
 
+    /// <summary>
+    /// A handler marked [PacketEncryption(true)] must be denied with ProtocolReason.FORBIDDEN
+    /// when the packet context reports the frame did not arrive encrypted on the wire —
+    /// EncryptedOnWire is the dedicated audit signal CanExecute reads (the packet header's
+    /// transient ENCRYPTED flag is cleared by the inbound cipher transforms and cannot be
+    /// used for this check).
+    /// </summary>
+    [Fact]
+    public void CanExecute_EncryptionRequiredAndFrameNotEncryptedOnWire_DeniesWithForbidden()
+    {
+        PacketHandler<TestPacket> descriptor = CreateDescriptor(
+            (_, _) => new ValueTask<object?>((object?)null), requireEncryption: true);
+
+        PacketContext<TestPacket> context = new();
+        FakeConnection connection = new();
+        try
+        {
+            context.Initialize(
+                new TestPacket(), connection, descriptor.Metadata,
+                reliable: true, encryptedOnWire: false);
+
+            bool canExecute = descriptor.CanExecute(context, out ProtocolReason denyReason);
+
+            canExecute.Should().BeFalse();
+            denyReason.Should().Be(ProtocolReason.FORBIDDEN);
+        }
+        finally
+        {
+            context.Return();
+            connection.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// A handler marked [PacketEncryption(true)] must be allowed to execute when the packet
+    /// context reports the frame did arrive encrypted on the wire.
+    /// </summary>
+    [Fact]
+    public void CanExecute_EncryptionRequiredAndFrameEncryptedOnWire_Allows()
+    {
+        PacketHandler<TestPacket> descriptor = CreateDescriptor(
+            (_, _) => new ValueTask<object?>((object?)null), requireEncryption: true);
+
+        PacketContext<TestPacket> context = new();
+        FakeConnection connection = new();
+        try
+        {
+            context.Initialize(
+                new TestPacket(), connection, descriptor.Metadata,
+                reliable: true, encryptedOnWire: true);
+
+            bool canExecute = descriptor.CanExecute(context, out ProtocolReason denyReason);
+
+            canExecute.Should().BeTrue();
+            denyReason.Should().Be(ProtocolReason.NONE);
+        }
+        finally
+        {
+            context.Return();
+            connection.Dispose();
+        }
+    }
+
     private static PacketHandler<TestPacket> CreateDescriptor(
-        Func<object?, PacketContext<TestPacket>, ValueTask<object?>> invoker, int timeoutMs = 0)
-        => CreateDescriptor<TestPacket>(invoker, timeoutMs);
+        Func<object?, PacketContext<TestPacket>, ValueTask<object?>> invoker,
+        int timeoutMs = 0, bool requireEncryption = false)
+        => CreateDescriptor<TestPacket>(invoker, timeoutMs, requireEncryption);
 
     private static PacketHandler<TPacket> CreateDescriptor<TPacket>(
-        Func<object?, PacketContext<TPacket>, ValueTask<object?>> invoker, int timeoutMs = 0)
+        Func<object?, PacketContext<TPacket>, ValueTask<object?>> invoker,
+        int timeoutMs = 0, bool requireEncryption = false)
         where TPacket : IPacket
     {
         PacketTimeoutAttribute? timeout = timeoutMs > 0 ? new PacketTimeoutAttribute(timeoutMs) : null;
+        PacketEncryptionAttribute? encryption = requireEncryption ? new PacketEncryptionAttribute(true) : null;
         PacketMetadata metadata = new(
             opCode: new PacketOpcodeAttribute((ushort)1),
             timeout: timeout,
             permission: null,
-            encryption: null,
+            encryption: encryption,
             rateLimit: null,
             transport: null);
 


### PR DESCRIPTION
CanExecute previously only checked Metadata.Permission. Handlers marked [PacketEncryption(true)] had no runtime enforcement, letting a fully plaintext request reach them (e.g. ObservabilityAccessHandlers), which allowed remote SUPERVISOR privilege escalation without breaking any crypto (CWE-319).