### PR TITLE
refactor: error handling to include originating socket

### DIFF
--- a/src/Nalix.SDK/Transport/Internal/Tcp/TcpFrameReader.cs
+++ b/src/Nalix.SDK/Transport/Internal/Tcp/TcpFrameReader.cs
@@ -33,7 +33,7 @@ internal sealed class TcpFrameReader : IDisposable
     private readonly SequenceCounter _sequence;
     internal SequenceCounter Sequence => _sequence;
     private readonly TransportOptions _options;
-    private readonly Action<Exception> _onError;
+    private readonly Action<Exception, Socket?> _onError;
     private readonly Action<IBufferLease> _onMessage;
 
     private readonly FragmentAssembler _fragmentAssembler = new()
@@ -50,7 +50,7 @@ internal sealed class TcpFrameReader : IDisposable
         TransportOptions options,
         SessionState state,
         Action<IBufferLease> onMessage,
-        Action<Exception> onError)
+        Action<Exception, Socket?> onError)
     {
         _sequence = new SequenceCounter();
         _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -121,7 +121,7 @@ internal sealed class TcpFrameReader : IDisposable
                     }
                     catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex) && ex is not OperationCanceledException)
                     {
-                        _onError(ex);
+                        _onError(ex, s);
                         break;
                     }
                 }
@@ -134,7 +134,7 @@ internal sealed class TcpFrameReader : IDisposable
         catch (OperationCanceledException) when (token.IsCancellationRequested) { }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
-            _onError(ex);
+            _onError(ex, _getSocket());
         }
         finally
         {

--- a/src/Nalix.SDK/Transport/Internal/Tcp/TcpFrameSender.cs
+++ b/src/Nalix.SDK/Transport/Internal/Tcp/TcpFrameSender.cs
@@ -27,7 +27,7 @@ internal sealed class TcpFrameSender : IDisposable
     private readonly SemaphoreSlim _sendLock;
     private readonly SequenceCounter _sequence;
     internal SequenceCounter Sequence => _sequence;
-    private readonly Action<Exception> _onError;
+    private readonly Action<Exception, Socket?> _onError;
 
     private readonly SessionState _state;
     private readonly TransportOptions _options;
@@ -39,7 +39,7 @@ internal sealed class TcpFrameSender : IDisposable
         Func<Socket> getSocket,
         TransportOptions options,
         SessionState state,
-        Action<Exception> onError)
+        Action<Exception, Socket?> onError)
     {
         _sendLock = new(1, 1);
         _sequence = new SequenceCounter();
@@ -94,7 +94,7 @@ internal sealed class TcpFrameSender : IDisposable
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
-            _onError?.Invoke(ex);
+            _onError?.Invoke(ex, _getSocket());
             return false;
         }
         finally

--- a/src/Nalix.SDK/Transport/Internal/Udp/UdpFrameReader.cs
+++ b/src/Nalix.SDK/Transport/Internal/Udp/UdpFrameReader.cs
@@ -33,7 +33,7 @@ internal sealed class UdpFrameReader : IDisposable
     private readonly SequenceCounter _sequence;
     internal SequenceCounter Sequence => _sequence;
     private readonly TransportOptions _options;
-    private readonly Action<Exception> _onError;
+    private readonly Action<Exception, Socket?> _onError;
     private readonly Action<IBufferLease> _onMessageReceived;
     private readonly Func<Func<ReadOnlyMemory<byte>, Task>?> _getOnMessageAsync;
 
@@ -54,7 +54,7 @@ internal sealed class UdpFrameReader : IDisposable
         SessionState state,
         Action<IBufferLease> onMessageReceived,
         Func<Func<ReadOnlyMemory<byte>, Task>?> getOnMessageAsync,
-        Action<Exception> onError)
+        Action<Exception, Socket?> onError)
     {
         _sequence = new SequenceCounter();
         _getSocket = getSocket ?? throw new ArgumentNullException(nameof(getSocket));
@@ -109,7 +109,7 @@ internal sealed class UdpFrameReader : IDisposable
                 {
                     if (!cancellationToken.IsCancellationRequested)
                     {
-                        _onError(ex);
+                        _onError(ex, socket);
                     }
                     break;
                 }
@@ -125,7 +125,7 @@ internal sealed class UdpFrameReader : IDisposable
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
-            _onError(ex);
+            _onError(ex, socket);
         }
     }
 
@@ -220,7 +220,7 @@ internal sealed class UdpFrameReader : IDisposable
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
-                _onError(ex);
+                _onError(ex, _getSocket());
             }
             finally
             {

--- a/src/Nalix.SDK/Transport/Internal/Udp/UdpFrameSender.cs
+++ b/src/Nalix.SDK/Transport/Internal/Udp/UdpFrameSender.cs
@@ -28,14 +28,14 @@ internal sealed class UdpFrameSender : IDisposable
     private readonly Func<Socket> _getSocket;
     private readonly SequenceCounter _sequence;
     private readonly TransportOptions _options;
-    private readonly Action<Exception> _onError;
+    private readonly Action<Exception, Socket?> _onError;
     private readonly SemaphoreSlim _sendLock = new(1, 1);
 
     internal SequenceCounter Sequence => _sequence;
 
     private int _disposed;
 
-    public UdpFrameSender(Func<Socket> getSocket, TransportOptions options, SessionState state, Action<Exception> onError)
+    public UdpFrameSender(Func<Socket> getSocket, TransportOptions options, SessionState state, Action<Exception, Socket?> onError)
     {
         _sequence = new SequenceCounter();
         _getSocket = getSocket ?? throw new ArgumentNullException(nameof(getSocket));
@@ -107,7 +107,7 @@ internal sealed class UdpFrameSender : IDisposable
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
-            _onError(ex);
+            _onError(ex, _getSocket());
             return false;
         }
         finally
@@ -132,7 +132,7 @@ internal sealed class UdpFrameSender : IDisposable
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
-            _onError(ex);
+            _onError(ex, socket);
             return false;
         }
         finally

--- a/src/Nalix.SDK/Transport/Internal/Ws/WsFrameReader.cs
+++ b/src/Nalix.SDK/Transport/Internal/Ws/WsFrameReader.cs
@@ -21,7 +21,7 @@ internal sealed class WsFrameReader : IDisposable
 {
     private static readonly SequenceOptions s_sequenceOptions = ConfigurationManager.Instance.Get<SequenceOptions>();
 
-    private readonly Action<Exception> _onError;
+    private readonly Action<Exception, ClientWebSocket?> _onError;
     private readonly Action<IBufferLease> _onMessage;
     private readonly Func<ClientWebSocket> _getSocket;
 
@@ -39,7 +39,7 @@ internal sealed class WsFrameReader : IDisposable
         SessionState state,
         WebSocketTransportOptions webSocketOptions,
         Action<IBufferLease> onMessage,
-        Action<Exception> onError)
+        Action<Exception, ClientWebSocket?> onError)
     {
         _sequence = new SequenceCounter();
         _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -100,11 +100,11 @@ internal sealed class WsFrameReader : IDisposable
             BufferLease.ByteArrayPool.Return(buffer);
             if (disconnectReason != null)
             {
-                _onError?.Invoke(disconnectReason);
+                _onError?.Invoke(disconnectReason, socket);
             }
             else if (!ct.IsCancellationRequested)
             {
-                _onError?.Invoke(new WebSocketException(WebSocketError.ConnectionClosedPrematurely, "The WebSocket session was disconnected."));
+                _onError?.Invoke(new WebSocketException(WebSocketError.ConnectionClosedPrematurely, "The WebSocket session was disconnected."), socket);
             }
         }
     }
@@ -191,7 +191,7 @@ internal sealed class WsFrameReader : IDisposable
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
-            _onError?.Invoke(ex);
+            _onError?.Invoke(ex, _getSocket());
         }
         finally
         {

--- a/src/Nalix.SDK/Transport/Internal/Ws/WsFrameSender.cs
+++ b/src/Nalix.SDK/Transport/Internal/Ws/WsFrameSender.cs
@@ -21,12 +21,12 @@ internal sealed class WsFrameSender : IDisposable
     private readonly SequenceCounter _sequence;
     internal SequenceCounter Sequence => _sequence;
     private readonly TransportOptions _options;
-    private readonly Action<Exception> _onError;
+    private readonly Action<Exception, ClientWebSocket?> _onError;
     private readonly Func<ClientWebSocket> _getSocket;
 
     private int _disposed;
 
-    public WsFrameSender(Func<ClientWebSocket> getSocket, TransportOptions options, SessionState state, Action<Exception> onError)
+    public WsFrameSender(Func<ClientWebSocket> getSocket, TransportOptions options, SessionState state, Action<Exception, ClientWebSocket?> onError)
     {
         _sendLock = new(1, 1);
         _sequence = new SequenceCounter();
@@ -82,7 +82,7 @@ internal sealed class WsFrameSender : IDisposable
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
-            _onError?.Invoke(ex);
+            _onError?.Invoke(ex, _getSocket());
             return false;
         }
         finally
@@ -112,7 +112,7 @@ internal sealed class WsFrameSender : IDisposable
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
-            _onError?.Invoke(ex);
+            _onError?.Invoke(ex, socket);
             return false;
         }
         finally
@@ -137,7 +137,7 @@ internal sealed class WsFrameSender : IDisposable
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
-            _onError?.Invoke(ex);
+            _onError?.Invoke(ex, socket);
             return false;
         }
         finally

--- a/src/Nalix.SDK/Transport/TcpSession.cs
+++ b/src/Nalix.SDK/Transport/TcpSession.cs
@@ -241,11 +241,31 @@ public class TcpSession : TransportSession
         }
     }
 
-    private async Task DisconnectInternalAsync(bool waitForLoop = false)
+    private async Task DisconnectInternalAsync(Socket? expectedSocket = null, bool waitForLoop = false)
     {
-        CancellationTokenSource? loopCts = Interlocked.Exchange(ref _loopCts, null);
-        Task? loopTask = Interlocked.Exchange(ref _loopTask, null);
-        Socket? socket = Interlocked.Exchange(ref _socket, null);
+        Socket? socket;
+        CancellationTokenSource? loopCts;
+        Task? loopTask;
+
+        if (expectedSocket is not null)
+        {
+            socket = Interlocked.CompareExchange(ref _socket, null, expectedSocket);
+            if (!ReferenceEquals(socket, expectedSocket))
+            {
+                // The socket field has already moved to a newer connection or been cleaned up.
+                // Do not tear down the newer connection!
+                return;
+            }
+
+            loopCts = Interlocked.Exchange(ref _loopCts, null);
+            loopTask = Interlocked.Exchange(ref _loopTask, null);
+        }
+        else
+        {
+            loopCts = Interlocked.Exchange(ref _loopCts, null);
+            loopTask = Interlocked.Exchange(ref _loopTask, null);
+            socket = Interlocked.Exchange(ref _socket, null);
+        }
 
         try
         {
@@ -365,13 +385,18 @@ public class TcpSession : TransportSession
 
     #region Private
 
-    private void HandleError(Exception ex)
+    private void HandleError(Exception ex, Socket? originatingSocket = null)
     {
+        if (originatingSocket is not null && !ReferenceEquals(Volatile.Read(ref _socket), originatingSocket))
+        {
+            return;
+        }
+
         this.OnError?.Invoke(this, ex);
         // Do not go through the public DisconnectAsync() path — that marks the disconnect as
         // intentional (app-initiated), which would suppress auto-reconnect for what is actually
         // an unexpected fault.
-        _ = this.DisconnectInternalAsync();
+        _ = this.DisconnectInternalAsync(expectedSocket: originatingSocket);
     }
 
     /// <summary>

--- a/src/Nalix.SDK/Transport/UdpSession.cs
+++ b/src/Nalix.SDK/Transport/UdpSession.cs
@@ -219,11 +219,30 @@ public class UdpSession : TransportSession
         }
     }
 
-    private async Task DisconnectInternalAsync(bool waitForLoop = false)
+    private async Task DisconnectInternalAsync(Socket? expectedSocket = null, bool waitForLoop = false)
     {
-        CancellationTokenSource? cts = Interlocked.Exchange(ref _loopCts, null);
-        Task? loopTask = Interlocked.Exchange(ref _loopTask, null);
-        Socket? socket = Interlocked.Exchange(ref _socket, null);
+        Socket? socket;
+        CancellationTokenSource? cts;
+        Task? loopTask;
+
+        if (expectedSocket is not null)
+        {
+            socket = Interlocked.CompareExchange(ref _socket, null, expectedSocket);
+            if (!ReferenceEquals(socket, expectedSocket))
+            {
+                // Socket already swapped or cleaned up by another thread.
+                return;
+            }
+
+            cts = Interlocked.Exchange(ref _loopCts, null);
+            loopTask = Interlocked.Exchange(ref _loopTask, null);
+        }
+        else
+        {
+            cts = Interlocked.Exchange(ref _loopCts, null);
+            loopTask = Interlocked.Exchange(ref _loopTask, null);
+            socket = Interlocked.Exchange(ref _socket, null);
+        }
 
         try
         {
@@ -312,13 +331,18 @@ public class UdpSession : TransportSession
 
     #region Private Handlers
 
-    private void HandleError(Exception ex)
+    private void HandleError(Exception ex, Socket? originatingSocket = null)
     {
+        if (originatingSocket is not null && !ReferenceEquals(Volatile.Read(ref _socket), originatingSocket))
+        {
+            return;
+        }
+
         this.OnError?.Invoke(this, ex);
         // Do not go through the public DisconnectAsync() path — that marks the disconnect as
         // intentional (app-initiated), which would suppress auto-reconnect for what is actually
         // an unexpected fault.
-        _ = this.DisconnectInternalAsync();
+        _ = this.DisconnectInternalAsync(expectedSocket: originatingSocket);
     }
 
     /// <summary>

--- a/src/Nalix.SDK/Transport/WebSocketSession.cs
+++ b/src/Nalix.SDK/Transport/WebSocketSession.cs
@@ -179,11 +179,31 @@ public class WebSocketSession : TransportSession
         }
     }
 
-    private async Task DisconnectInternalAsync(bool waitForLoop = false)
+    private async Task DisconnectInternalAsync(ClientWebSocket? expectedSocket = null, bool waitForLoop = false)
     {
-        CancellationTokenSource? loopCts = Interlocked.Exchange(ref _loopCts, null);
-        Task? loopTask = Interlocked.Exchange(ref _loopTask, null);
-        ClientWebSocket? socket = Interlocked.Exchange(ref _socket, null);
+        ClientWebSocket? socket;
+        CancellationTokenSource? loopCts;
+        Task? loopTask;
+
+        if (expectedSocket is not null)
+        {
+            socket = Interlocked.CompareExchange(ref _socket, null, expectedSocket);
+            if (!ReferenceEquals(socket, expectedSocket))
+            {
+                // The socket field has already moved to a newer connection or been cleaned up.
+                // Do not tear down the newer connection!
+                return;
+            }
+
+            loopCts = Interlocked.Exchange(ref _loopCts, null);
+            loopTask = Interlocked.Exchange(ref _loopTask, null);
+        }
+        else
+        {
+            loopCts = Interlocked.Exchange(ref _loopCts, null);
+            loopTask = Interlocked.Exchange(ref _loopTask, null);
+            socket = Interlocked.Exchange(ref _socket, null);
+        }
 
         try
         {
@@ -306,13 +326,18 @@ public class WebSocketSession : TransportSession
         return normalized[0] == '/' ? normalized : "/" + normalized;
     }
 
-    private void HandleError(Exception ex)
+    private void HandleError(Exception ex, ClientWebSocket? originatingSocket = null)
     {
+        if (originatingSocket is not null && !ReferenceEquals(Volatile.Read(ref _socket), originatingSocket))
+        {
+            return;
+        }
+
         this.OnError?.Invoke(this, ex);
         // Do not go through the public DisconnectAsync() path — that marks the disconnect as
         // intentional (app-initiated), which would suppress auto-reconnect for what is actually
         // an unexpected fault.
-        _ = this.DisconnectInternalAsync();
+        _ = this.DisconnectInternalAsync(expectedSocket: originatingSocket);
     }
 
     private void HandleReceiveMessage(IBufferLease lease)

--- a/tests/Nalix.SDK.Tests/PacketAwaiterTests.cs
+++ b/tests/Nalix.SDK.Tests/PacketAwaiterTests.cs
@@ -46,6 +46,7 @@ public sealed class PacketAwaiterTests
         public ManualLease(byte[] data) => _data = data;
         public int Length => _data.Length;
         public bool IsReliable { get; set; }
+        public bool EncryptedOnWire { get; set; }
         public int Capacity => _data.Length;
         public Span<byte> Span => _data;
         public Span<byte> SpanFull => _data;


### PR DESCRIPTION
Updated error callback signatures in TCP, UDP, and WebSocket frame readers/senders to accept the originating socket. Session classes now only disconnect the expected socket, preventing teardown of newer connections in concurrent scenarios. Refactored DisconnectInternalAsync to support this logic. Added EncryptedOnWire property to ManualLease in tests.