### PR TITLE
feat: per-packet DI with IPacketScope and [FromScope]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ research/
 /.playwright-mcp
 /WsTest
 /scratch.cs
+/.scratch

--- a/analyzers/Nalix.Analyzers.Generators/Internal/KnownNames.cs
+++ b/analyzers/Nalix.Analyzers.Generators/Internal/KnownNames.cs
@@ -35,6 +35,7 @@ internal class KnownNames
     public const string PacketEncryptionAttributeMetadataName = "Nalix.Abstractions.Networking.Packets.PacketEncryptionAttribute";
     public const string PacketRateLimitAttributeMetadataName = "Nalix.Abstractions.Networking.Packets.PacketRateLimitAttribute";
     public const string PacketTransportAttributeMetadataName = "Nalix.Abstractions.Networking.Packets.PacketTransportAttribute";
+    public const string FromScopeAttributeMetadataName = "Nalix.Abstractions.Injection.FromScopeAttribute";
     public const string RpcServiceAttributeMetadataName = "Nalix.Abstractions.Networking.Rpc.RpcServiceAttribute";
 
     // Types

--- a/analyzers/Nalix.Analyzers.Generators/PacketHandlerGenerator.cs
+++ b/analyzers/Nalix.Analyzers.Generators/PacketHandlerGenerator.cs
@@ -288,7 +288,9 @@ public sealed class PacketHandlerGenerator : IIncrementalGenerator
 
             if (firstParam.Type is INamedTypeSymbol namedParam && namedParam.IsGenericType && namedParam.TypeArguments.Length == 1)
             {
-                if (namedParam.Name is "IPacketContext" or "PacketContext" || namedParam.ToDisplayString().Contains("IPacketContext"))
+                string originalDef = namedParam.OriginalDefinition.ToDisplayString();
+                if (originalDef is "Nalix.Abstractions.Networking.Packets.IPacketContext<TPacket>"
+                    or "Nalix.Runtime.Dispatching.PacketContext<TPacket>")
                 {
                     packetType = namedParam.TypeArguments[0] as INamedTypeSymbol;
                     isGenericContext = true;
@@ -303,6 +305,7 @@ public sealed class PacketHandlerGenerator : IIncrementalGenerator
                 continue;
             }
 
+            bool allScopeParamsValid = true;
             ImmutableArray<ScopeParameterModel>.Builder scopeParams = ImmutableArray.CreateBuilder<ScopeParameterModel>();
             for (int i = 1; i < method.Parameters.Length; i++)
             {
@@ -311,10 +314,22 @@ public sealed class PacketHandlerGenerator : IIncrementalGenerator
                     a.AttributeClass?.ToDisplayString() == KnownNames.FromScopeAttributeMetadataName
                     || a.AttributeClass?.Name is "FromScope" or "FromScopeAttribute");
 
+                // Trailing parameters MUST have [FromScope] AND must be reference types (class constraint)
+                if (!hasFromScope || !sp.Type.IsReferenceType)
+                {
+                    allScopeParamsValid = false;
+                    break;
+                }
+
                 string spTypeStr = sp.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
                 bool isNullable = sp.NullableAnnotation == NullableAnnotation.Annotated;
 
                 scopeParams.Add(new ScopeParameterModel(sp.Name, spTypeStr, isNullable, hasFromScope));
+            }
+
+            if (!allScopeParamsValid)
+            {
+                continue;
             }
 
             string? pTypeStr = packetType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);

--- a/analyzers/Nalix.Analyzers.Generators/PacketHandlerGenerator.cs
+++ b/analyzers/Nalix.Analyzers.Generators/PacketHandlerGenerator.cs
@@ -18,6 +18,43 @@ namespace Nalix.Analyzers.Generators;
 [Generator]
 public sealed class PacketHandlerGenerator : IIncrementalGenerator
 {
+    public readonly struct ScopeParameterModel : IEquatable<ScopeParameterModel>
+    {
+        public string Name { get; }
+        public string TypeFullyQualifiedStr { get; }
+        public bool IsNullable { get; }
+        public bool IsFromScope { get; }
+
+        public ScopeParameterModel(string name, string typeFullyQualifiedStr, bool isNullable, bool isFromScope)
+        {
+            this.Name = name;
+            this.TypeFullyQualifiedStr = typeFullyQualifiedStr;
+            this.IsNullable = isNullable;
+            this.IsFromScope = isFromScope;
+        }
+
+        public bool Equals(ScopeParameterModel other) =>
+            this.Name == other.Name &&
+            this.TypeFullyQualifiedStr == other.TypeFullyQualifiedStr &&
+            this.IsNullable == other.IsNullable &&
+            this.IsFromScope == other.IsFromScope;
+
+        public override bool Equals(object obj) => obj is ScopeParameterModel other && this.Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = (hash * 23) + (this.Name?.GetHashCode() ?? 0);
+                hash = (hash * 23) + (this.TypeFullyQualifiedStr?.GetHashCode() ?? 0);
+                hash = (hash * 23) + this.IsNullable.GetHashCode();
+                hash = (hash * 23) + this.IsFromScope.GetHashCode();
+                return hash;
+            }
+        }
+    }
+
     public readonly struct HandlerMethodModel : IEquatable<HandlerMethodModel>
     {
         public string MethodName { get; }
@@ -30,11 +67,13 @@ public sealed class PacketHandlerGenerator : IIncrementalGenerator
         public string MetadataExpr { get; }
         public bool ReturnsTaskOrValueTask { get; }
         public bool ReturnsVoid { get; }
+        public ImmutableArray<ScopeParameterModel> ScopeParameters { get; }
 
         public HandlerMethodModel(
             string methodName, bool isStatic, ushort opcodeVal, string returnTypeStr,
             string expectedPacketTypeStr, bool isGenericContext, string? packetTypeStr,
-            string metadataExpr, bool returnsTaskOrValueTask, bool returnsVoid)
+            string metadataExpr, bool returnsTaskOrValueTask, bool returnsVoid,
+            ImmutableArray<ScopeParameterModel> scopeParameters)
         {
             this.MethodName = methodName;
             this.IsStatic = isStatic;
@@ -46,6 +85,7 @@ public sealed class PacketHandlerGenerator : IIncrementalGenerator
             this.MetadataExpr = metadataExpr;
             this.ReturnsTaskOrValueTask = returnsTaskOrValueTask;
             this.ReturnsVoid = returnsVoid;
+            this.ScopeParameters = scopeParameters;
         }
 
         public bool Equals(HandlerMethodModel other) =>
@@ -58,7 +98,8 @@ public sealed class PacketHandlerGenerator : IIncrementalGenerator
             this.PacketTypeStr == other.PacketTypeStr &&
             this.MetadataExpr == other.MetadataExpr &&
             this.ReturnsTaskOrValueTask == other.ReturnsTaskOrValueTask &&
-            this.ReturnsVoid == other.ReturnsVoid;
+            this.ReturnsVoid == other.ReturnsVoid &&
+            Internal.ModelEquality.SequenceEqual(this.ScopeParameters, other.ScopeParameters);
 
         public override bool Equals(object obj) => obj is HandlerMethodModel other && this.Equals(other);
 
@@ -77,6 +118,13 @@ public sealed class PacketHandlerGenerator : IIncrementalGenerator
                 hash = (hash * 23) + (this.MetadataExpr?.GetHashCode() ?? 0);
                 hash = (hash * 23) + this.ReturnsTaskOrValueTask.GetHashCode();
                 hash = (hash * 23) + this.ReturnsVoid.GetHashCode();
+                if (!this.ScopeParameters.IsDefaultOrEmpty)
+                {
+                    foreach (ScopeParameterModel p in this.ScopeParameters)
+                    {
+                        hash = (hash * 23) + p.GetHashCode();
+                    }
+                }
                 return hash;
             }
         }
@@ -229,24 +277,44 @@ public sealed class PacketHandlerGenerator : IIncrementalGenerator
 
             ushort opcodeVal = Convert.ToUInt16(val);
 
-            // Single canonical handler shape, kept in sync with NalixUsageAnalyzer's
-            // `HasSupportedParameterSignature` (NalixUsageAnalyzer.cs) — only a single
-            // `IPacketContext<T>` parameter is a supported handler signature; anything
-            // else is reported as NALIX003 by the analyzer, so silently skipping here
-            // is safe (no valid handler is ever dropped without a diagnostic).
-            if (method.Parameters.Length != 1)
+            if (method.Parameters.Length == 0)
             {
                 continue;
             }
 
-            IParameterSymbol param = method.Parameters[0];
+            IParameterSymbol firstParam = method.Parameters[0];
             INamedTypeSymbol? packetType = null;
             bool isGenericContext = false;
 
-            if (param.Type is INamedTypeSymbol namedParam && namedParam.IsGenericType && namedParam.TypeArguments.Length == 1)
+            if (firstParam.Type is INamedTypeSymbol namedParam && namedParam.IsGenericType && namedParam.TypeArguments.Length == 1)
             {
-                packetType = namedParam.TypeArguments[0] as INamedTypeSymbol;
-                isGenericContext = true;
+                if (namedParam.Name is "IPacketContext" or "PacketContext" || namedParam.ToDisplayString().Contains("IPacketContext"))
+                {
+                    packetType = namedParam.TypeArguments[0] as INamedTypeSymbol;
+                    isGenericContext = true;
+                }
+                else
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                continue;
+            }
+
+            ImmutableArray<ScopeParameterModel>.Builder scopeParams = ImmutableArray.CreateBuilder<ScopeParameterModel>();
+            for (int i = 1; i < method.Parameters.Length; i++)
+            {
+                IParameterSymbol sp = method.Parameters[i];
+                bool hasFromScope = sp.GetAttributes().Any(a =>
+                    a.AttributeClass?.ToDisplayString() == KnownNames.FromScopeAttributeMetadataName
+                    || a.AttributeClass?.Name is "FromScope" or "FromScopeAttribute");
+
+                string spTypeStr = sp.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                bool isNullable = sp.NullableAnnotation == NullableAnnotation.Annotated;
+
+                scopeParams.Add(new ScopeParameterModel(sp.Name, spTypeStr, isNullable, hasFromScope));
             }
 
             string? pTypeStr = packetType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
@@ -280,7 +348,8 @@ public sealed class PacketHandlerGenerator : IIncrementalGenerator
                 packetTypeStr: pTypeStr,
                 metadataExpr: metadataExpr,
                 returnsTaskOrValueTask: returnsTaskOrValueTask,
-                returnsVoid: returnsVoid
+                returnsVoid: returnsVoid,
+                scopeParameters: scopeParams.ToImmutable()
             ));
         }
 
@@ -411,28 +480,49 @@ public sealed class PacketHandlerGenerator : IIncrementalGenerator
             }
             else
             {
-                contextCast = "(global::Nalix.Abstractions.Networking.Packets.IPacketContext)context";
+                contextCast = "(global::Nalix.Abstractions.Networking.Packets.IPacketContext<TPacket>)context";
             }
+
+            List<string> callArgs = [contextCast];
+            if (!method.ScopeParameters.IsDefaultOrEmpty)
+            {
+                for (int i = 0; i < method.ScopeParameters.Length; i++)
+                {
+                    ScopeParameterModel sp = method.ScopeParameters[i];
+                    string argName = $"__scoped_{sp.Name}_{i}";
+                    if (sp.IsNullable)
+                    {
+                        _ = sb.AppendLine($"                var {argName} = context.Scope.GetService<{sp.TypeFullyQualifiedStr}>();");
+                    }
+                    else
+                    {
+                        _ = sb.AppendLine($"                var {argName} = context.Scope.GetRequiredService<{sp.TypeFullyQualifiedStr}>();");
+                    }
+                    callArgs.Add(argName);
+                }
+            }
+
+            string invocationArgs = string.Join(", ", callArgs);
 
             if (method.ReturnsVoid)
             {
-                _ = sb.AppendLine($"                    {typeCall}{method.MethodName}({contextCast});");
+                _ = sb.AppendLine($"                    {typeCall}{method.MethodName}({invocationArgs});");
                 _ = sb.AppendLine($"                    return null;");
             }
             else if (method.ReturnsTaskOrValueTask)
             {
-                _ = sb.AppendLine($"                    await {typeCall}{method.MethodName}({contextCast});");
+                _ = sb.AppendLine($"                    await {typeCall}{method.MethodName}({invocationArgs});");
                 _ = sb.AppendLine($"                    return null;");
             }
             else
             {
                 if (method.ReturnTypeStr.Contains("System.Threading.Tasks.Task") || method.ReturnTypeStr.Contains("System.Threading.Tasks.ValueTask"))
                 {
-                    _ = sb.AppendLine($"                    return await {typeCall}{method.MethodName}({contextCast});");
+                    _ = sb.AppendLine($"                    return await {typeCall}{method.MethodName}({invocationArgs});");
                 }
                 else
                 {
-                    _ = sb.AppendLine($"                    return {typeCall}{method.MethodName}({contextCast});");
+                    _ = sb.AppendLine($"                    return {typeCall}{method.MethodName}({invocationArgs});");
                 }
             }
 

--- a/analyzers/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.SymbolSet.cs
+++ b/analyzers/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.SymbolSet.cs
@@ -56,6 +56,7 @@ public sealed partial class NalixUsageAnalyzer
             INamedTypeSymbol? exceptionClassifierType,
             INamedTypeSymbol? packetScopeType,
             INamedTypeSymbol? caughtExceptionType,
+            INamedTypeSymbol? fromScopeAttribute,
             INamedTypeSymbol? rpcServiceAttribute,
             INamedTypeSymbol? rpcCallType,
             INamedTypeSymbol? rpcStreamType,
@@ -103,6 +104,7 @@ public sealed partial class NalixUsageAnalyzer
             this.ExceptionClassifierType = exceptionClassifierType;
             this.PacketScopeType = packetScopeType;
             this.CaughtExceptionType = caughtExceptionType;
+            this.FromScopeAttribute = fromScopeAttribute;
             this.RpcServiceAttribute = rpcServiceAttribute;
             this.RpcCallType = rpcCallType;
             this.RpcStreamType = rpcStreamType;
@@ -151,6 +153,7 @@ public sealed partial class NalixUsageAnalyzer
         public INamedTypeSymbol? ExceptionClassifierType { get; }
         public INamedTypeSymbol? PacketScopeType { get; }
         public INamedTypeSymbol? CaughtExceptionType { get; }
+        public INamedTypeSymbol? FromScopeAttribute { get; }
         public INamedTypeSymbol? RpcServiceAttribute { get; }
         public INamedTypeSymbol? RpcCallType { get; }
         public INamedTypeSymbol? RpcStreamType { get; }
@@ -205,6 +208,7 @@ public sealed partial class NalixUsageAnalyzer
             INamedTypeSymbol? exceptionClassifierType = compilation.GetTypeByMetadataName("Nalix.Abstractions.Exceptions.ExceptionClassifier");
             INamedTypeSymbol? packetScopeType = compilation.GetTypeByMetadataName("Nalix.Codec.Pooling.PacketScope`1");
             INamedTypeSymbol? caughtExceptionType = compilation.GetTypeByMetadataName("System.Exception");
+            INamedTypeSymbol? fromScopeAttribute = compilation.GetTypeByMetadataName("Nalix.Abstractions.Injection.FromScopeAttribute");
             INamedTypeSymbol? rpcServiceAttribute = compilation.GetTypeByMetadataName("Nalix.Abstractions.Networking.Rpc.RpcServiceAttribute");
             INamedTypeSymbol? rpcCallType = compilation.GetTypeByMetadataName("Nalix.SDK.Transport.Rpc.RpcCall`1");
             INamedTypeSymbol? rpcStreamType = compilation.GetTypeByMetadataName("Nalix.SDK.Transport.Rpc.RpcStream`1");
@@ -290,6 +294,7 @@ public sealed partial class NalixUsageAnalyzer
                     exceptionClassifierType,
                     packetScopeType,
                     caughtExceptionType,
+                    fromScopeAttribute,
                     rpcServiceAttribute,
                     rpcCallType,
                     rpcStreamType,

--- a/analyzers/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.cs
+++ b/analyzers/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.cs
@@ -782,13 +782,32 @@ public sealed partial class NalixUsageAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    // Single canonical handler shape, kept in sync with PacketHandlerGenerator's
-    // `Parameters.Length != 1` guard (PacketHandlerGenerator.cs) — only
-    // `IPacketContext<T>` (exactly one parameter) is a supported handler signature.
+    // Canonical handler shape: first parameter is IPacketContext<T>, optional trailing parameters must be annotated with [FromScope]
     private static bool HasSupportedParameterSignature(IMethodSymbol methodSymbol, SymbolSet symbols)
     {
         ImmutableArray<IParameterSymbol> parameters = methodSymbol.Parameters;
-        return parameters.Length == 1 && IsPacketContext(parameters[0].Type, symbols);
+        if (parameters.Length == 0 || !IsPacketContext(parameters[0].Type, symbols))
+        {
+            return false;
+        }
+
+        for (int i = 1; i < parameters.Length; i++)
+        {
+            IParameterSymbol param = parameters[i];
+            if (symbols.FromScopeAttribute is not null && HasAttribute(param, symbols.FromScopeAttribute))
+            {
+                continue;
+            }
+
+            if (param.GetAttributes().Any(a => a.AttributeClass?.Name is "FromScope" or "FromScopeAttribute"))
+            {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
     }
 
     private static bool HasSupportedReturnType(ITypeSymbol returnType, SymbolSet symbols)

--- a/analyzers/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.cs
+++ b/analyzers/Nalix.Analyzers/Analyzers/NalixUsageAnalyzer.cs
@@ -794,12 +794,19 @@ public sealed partial class NalixUsageAnalyzer : DiagnosticAnalyzer
         for (int i = 1; i < parameters.Length; i++)
         {
             IParameterSymbol param = parameters[i];
+            if (!param.Type.IsReferenceType)
+            {
+                return false;
+            }
+
             if (symbols.FromScopeAttribute is not null && HasAttribute(param, symbols.FromScopeAttribute))
             {
                 continue;
             }
 
-            if (param.GetAttributes().Any(a => a.AttributeClass?.Name is "FromScope" or "FromScopeAttribute"))
+            if (param.GetAttributes().Any(a =>
+                a.AttributeClass?.ToDisplayString() == "Nalix.Abstractions.Injection.FromScopeAttribute"
+                || (symbols.FromScopeAttribute is null && a.AttributeClass?.Name is "FromScope" or "FromScopeAttribute")))
             {
                 continue;
             }

--- a/analyzers/Nalix.Analyzers/Diagnostics/DiagnosticDescriptors.cs
+++ b/analyzers/Nalix.Analyzers/Diagnostics/DiagnosticDescriptors.cs
@@ -28,11 +28,11 @@ internal static class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor InvalidControllerHandlerSignature = new(
         id: "NALIX003",
         title: "Packet controller handler has unsupported signature",
-        messageFormat: "Handler method '{0}' has unsupported Nalix signature. Only 'public [static] <void|Task|ValueTask|Task<T>|ValueTask<T>> {0}(IPacketContext<TPacket> context)' is supported; use context.CancellationToken and context.Connection instead of separate parameters.",
+        messageFormat: "Handler method '{0}' has unsupported Nalix signature. Supported signatures require the first parameter to be IPacketContext<TPacket>, and any additional parameters must be annotated with [FromScope].",
         category: "Usage",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Nalix packet handlers must use the single canonical IPacketContext<T> signature supported by the source-generated handler invoker (PacketHandlerGenerator).");
+        description: "Nalix packet handlers must use IPacketContext<T> as the first parameter and [FromScope] for additional parameters supported by PacketHandlerGenerator.");
 
     public static readonly DiagnosticDescriptor PacketContextTypeMismatch = new(
         id: "NALIX004",

--- a/src/Nalix.Abstractions/Injection/FromScopeAttribute.cs
+++ b/src/Nalix.Abstractions/Injection/FromScopeAttribute.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+
+namespace Nalix.Abstractions.Injection;
+
+/// <summary>
+/// Specifies that a packet handler method parameter should be resolved from the current <see cref="IPacketScope"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+public sealed class FromScopeAttribute : Attribute
+{
+}

--- a/src/Nalix.Abstractions/Injection/IPacketScope.cs
+++ b/src/Nalix.Abstractions/Injection/IPacketScope.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2025-2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+
+namespace Nalix.Abstractions.Injection;
+
+/// <summary>
+/// Defines a scope for managing the lifecycle of per-packet (scoped) dependencies.
+/// </summary>
+public interface IPacketScope : IDisposable, IAsyncDisposable
+{
+    /// <summary>
+    /// Gets a required service of type <typeparamref name="T"/> from the current packet scope.
+    /// </summary>
+    /// <typeparam name="T">The type of service to resolve.</typeparam>
+    /// <returns>The resolved service instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the service is not registered in the scope.</exception>
+    T GetRequiredService<T>() where T : class;
+
+    /// <summary>
+    /// Gets an optional service of type <typeparamref name="T"/> from the current packet scope.
+    /// </summary>
+    /// <typeparam name="T">The type of service to resolve.</typeparam>
+    /// <returns>The resolved service instance, or <see langword="null"/> if not registered.</returns>
+    T? GetService<T>() where T : class;
+
+    /// <summary>
+    /// Registers an <see cref="IDisposable"/> instance to be disposed when this scope completes.
+    /// </summary>
+    /// <param name="disposable">The disposable instance to register.</param>
+    void RegisterForDisposal(IDisposable disposable);
+
+    /// <summary>
+    /// Registers an <see cref="IAsyncDisposable"/> instance to be disposed asynchronously when this scope completes.
+    /// </summary>
+    /// <param name="asyncDisposable">The async disposable instance to register.</param>
+    void RegisterForDisposal(IAsyncDisposable asyncDisposable);
+}

--- a/src/Nalix.Abstractions/Networking/Packets/IPacketContext.cs
+++ b/src/Nalix.Abstractions/Networking/Packets/IPacketContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Threading;
+using Nalix.Abstractions.Injection;
 
 namespace Nalix.Abstractions.Networking.Packets;
 
@@ -54,6 +55,11 @@ public interface IPacketContext<TPacket> : IPoolable where TPacket : IPacket
     /// Use this instead of calling connection.TCP.SendAsync() directly.
     /// </summary>
     IPacketSender Sender { get; }
+
+    /// <summary>
+    /// Gets the scoped service provider associated with the current packet lifecycle.
+    /// </summary>
+    IPacketScope Scope { get; }
 
     /// <summary>
     /// Gets or sets the cancellation token associated with the packet context.

--- a/src/Nalix.Hosting/INetworkApplicationBuilder.cs
+++ b/src/Nalix.Hosting/INetworkApplicationBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Nalix.Abstractions;
+using Nalix.Abstractions.Injection;
 using Nalix.Abstractions.Networking;
 using Nalix.Abstractions.Networking.Packets;
 using Nalix.Environment.Configuration.Binding;
@@ -82,6 +83,14 @@ public interface INetworkApplicationBuilder
     /// <param name="manager">The manager instance to use.</param>
     /// <returns>The current builder instance.</returns>
     INetworkApplicationBuilder UseObjectPoolManager(IObjectPoolManager manager);
+
+    /// <summary>
+    /// Registers a scoped service factory that creates per-packet instances from the active <see cref="Nalix.Abstractions.Injection.IPacketScope"/>.
+    /// </summary>
+    /// <typeparam name="TService">The service contract type.</typeparam>
+    /// <param name="factory">The factory delegate used to construct the service.</param>
+    /// <returns>The current builder instance.</returns>
+    INetworkApplicationBuilder RegisterScoped<TService>(Func<IPacketScope, TService> factory) where TService : class;
 
     /// <summary>
     /// Adds a packet controller type using the default Nalix activator.

--- a/src/Nalix.Hosting/NetworkApplicationBuilder.cs
+++ b/src/Nalix.Hosting/NetworkApplicationBuilder.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Nalix.Abstractions;
+using Nalix.Abstractions.Injection;
 using Nalix.Abstractions.Networking;
 using Nalix.Abstractions.Networking.Packets;
 using Nalix.Abstractions.Security;
@@ -178,6 +179,14 @@ public sealed class NetworkApplicationBuilder : INetworkApplicationBuilder
             ObjectPoolManager.Configure(concrete);
         }
 
+        return this;
+    }
+
+    /// <inheritdoc />
+    public INetworkApplicationBuilder RegisterScoped<TService>(Func<IPacketScope, TService> factory) where TService : class
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        ScopedServiceRegistry.Instance.RegisterScoped(factory);
         return this;
     }
 

--- a/src/Nalix.Runtime/Dispatching/Options/PacketDispatchOptions.PublicMethods.cs
+++ b/src/Nalix.Runtime/Dispatching/Options/PacketDispatchOptions.PublicMethods.cs
@@ -337,7 +337,9 @@ public sealed partial class PacketDispatchOptions<TPacket>
         }
         catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
         {
+#pragma warning disable CA1849 // Non-async rollback path
             context.Dispose();
+#pragma warning restore CA1849
             throw;
         }
 
@@ -352,7 +354,9 @@ public sealed partial class PacketDispatchOptions<TPacket>
             }
             finally
             {
+#pragma warning disable CA1849 // Synchronous fast-path cleanup without async state machine allocation
                 context.Dispose();
+#pragma warning restore CA1849
             }
 
             return ValueTask.CompletedTask;
@@ -362,7 +366,7 @@ public sealed partial class PacketDispatchOptions<TPacket>
 
         static async ValueTask AwaitAndDisposeAsync(ValueTask operation, PacketContext<TPacket> pooledContext)
         {
-            using (pooledContext)
+            await using (pooledContext.ConfigureAwait(false))
             {
                 await operation.ConfigureAwait(false);
             }

--- a/src/Nalix.Runtime/Dispatching/PacketContext.cs
+++ b/src/Nalix.Runtime/Dispatching/PacketContext.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Nalix.Abstractions;
 using Nalix.Abstractions.Exceptions;
 using Nalix.Abstractions.Injection;
@@ -18,7 +19,7 @@ namespace Nalix.Runtime.Dispatching;
 /// executing. Instances are pooled so dispatch can reuse context objects without
 /// allocating on every packet.
 [DebuggerDisplay("IsInitialized={_isInitialized}")]
-public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable, IDisposable
+public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable, IDisposable, IAsyncDisposable
     where TPacket : IPacket
 {
     #region Static
@@ -257,11 +258,29 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
         _ = Interlocked.Exchange(ref _state, (int)PacketContextState.Pooled);
     }
 
-    /// <summary>
-    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-    /// </summary>
+    /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Dispose() => this.Return();
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public async ValueTask DisposeAsync()
+    {
+        if (_isInitialized)
+        {
+            if (_ownsPacket && this.Scope is IAsyncDisposable asyncScope)
+            {
+                await asyncScope.DisposeAsync().ConfigureAwait(false);
+                if (this.Scope is PacketScope pooledScope)
+                {
+                    s_pool.Return(pooledScope);
+                }
+                this.Scope = default!;
+            }
+        }
+
+        this.Return();
+    }
 
     #endregion IDisposable
 }

--- a/src/Nalix.Runtime/Dispatching/PacketContext.cs
+++ b/src/Nalix.Runtime/Dispatching/PacketContext.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Nalix.Abstractions;
 using Nalix.Abstractions.Exceptions;
+using Nalix.Abstractions.Injection;
 using Nalix.Abstractions.Networking;
 using Nalix.Abstractions.Networking.Packets;
 using Nalix.Framework.Memory.Objects;
@@ -98,6 +99,15 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
     }
 
     /// <inheritdoc/>
+    public IPacketScope Scope
+    {
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        get;
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        private set;
+    }
+
+    /// <inheritdoc/>
     public CancellationToken CancellationToken
     {
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
@@ -128,6 +138,7 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
         _state = (int)PacketContextState.Pooled;
 
         this.Sender = new PacketSender();
+        this.Scope = default!;
         this.Packet = default!;
         this.IsReliable = false;
         this.EncryptedOnWire = false;
@@ -149,6 +160,7 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
     /// <param name="encryptedOnWire">Whether the inbound frame arrived encrypted on the wire.</param>
     /// <param name="ownsPacket">Indicates whether the context owns the packet and is responsible for its disposal.</param>
     /// <param name="token">The cancellation token for the context.</param>
+    /// <param name="scope">An optional existing scope to attach (e.g. from a parent context during bridging).</param>
     /// <remarks>
     /// This method marks the pooled instance as in use before populating the
     /// packet-specific fields so the dispatcher can return it safely later.
@@ -157,7 +169,8 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void Initialize(
         TPacket packet, IConnection connection, PacketMetadata descriptor,
-        bool reliable, bool encryptedOnWire, bool ownsPacket = true, CancellationToken token = default)
+        bool reliable, bool encryptedOnWire, bool ownsPacket = true, CancellationToken token = default,
+        Nalix.Abstractions.Injection.IPacketScope? scope = null)
     {
         _ = Interlocked.Exchange(ref _state, (int)PacketContextState.InUse);
 
@@ -170,6 +183,7 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
         this.Connection = connection;
         this.Attributes = descriptor;
         this.CancellationToken = token;
+        this.Scope = scope ?? s_pool.Get<PacketScope>();
 
         this.Sender.Initialize(this);
 
@@ -217,6 +231,16 @@ public sealed class PacketContext<TPacket> : IPacketContext<TPacket>, IPoolable,
                 disposablePacket.Dispose();
             }
 
+            if (_ownsPacket && this.Scope is IDisposable disposableScope)
+            {
+                disposableScope.Dispose();
+                if (this.Scope is PacketScope pooledScope)
+                {
+                    s_pool.Return(pooledScope);
+                }
+            }
+
+            this.Scope = default!;
             this.Packet = default!;
             this.IsReliable = false;
             this.EncryptedOnWire = false;

--- a/src/Nalix.Runtime/Dispatching/PacketContextBridge.cs
+++ b/src/Nalix.Runtime/Dispatching/PacketContextBridge.cs
@@ -39,7 +39,8 @@ public static class PacketContextBridge
             baseContext.IsReliable,
             baseContext.EncryptedOnWire,
             ownsPacket: false,
-            baseContext.CancellationToken);
+            baseContext.CancellationToken,
+            scope: baseContext.Scope);
 
         return bridgeContext;
     }

--- a/src/Nalix.Runtime/Dispatching/PacketScope.cs
+++ b/src/Nalix.Runtime/Dispatching/PacketScope.cs
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Nalix.Abstractions;
+using Nalix.Abstractions.Exceptions;
+using Nalix.Abstractions.Injection;
+using Nalix.Framework.Injection;
+using Nalix.Runtime.Routing;
+
+namespace Nalix.Runtime.Dispatching;
+
+/// <summary>
+/// High-performance, zero-allocation packet scope that manages per-packet service resolutions and disposals.
+/// </summary>
+public sealed class PacketScope : IPacketScope, IPoolable, IDisposable, IAsyncDisposable
+{
+    private const int InitialCapacity = 16;
+    private const int InitialDisposableCapacity = 8;
+
+    private readonly ScopedServiceRegistry _registry;
+
+    private (Type Type, object Instance)[] _resolved = new (Type, object)[InitialCapacity];
+    private int _resolvedCount;
+
+    private IDisposable[] _disposables = new IDisposable[InitialDisposableCapacity];
+    private int _disposablesCount;
+
+    private IAsyncDisposable[] _asyncDisposables = new IAsyncDisposable[InitialDisposableCapacity];
+    private int _asyncDisposablesCount;
+
+    private int _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketScope"/> class.
+    /// </summary>
+    public PacketScope() : this(ScopedServiceRegistry.Instance)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketScope"/> class with an explicit registry.
+    /// </summary>
+    /// <param name="registry">The scoped service registry to resolve factories from.</param>
+    public PacketScope(ScopedServiceRegistry registry) => _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public T GetRequiredService<T>() where T : class
+    {
+        T? service = this.GetService<T>();
+        if (service is not null)
+        {
+            return service;
+        }
+
+        throw new InvalidOperationException(
+            $"No service for type '{typeof(T).FullName}' has been registered in the active packet scope or singleton container.");
+    }
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public T? GetService<T>() where T : class
+    {
+        Type targetType = typeof(T);
+
+        // 1. Fast linear scan over already resolved scoped instances (Zero Allocation)
+        for (int i = 0; i < _resolvedCount; i++)
+        {
+            if (_resolved[i].Type == targetType)
+            {
+                return (T)_resolved[i].Instance;
+            }
+        }
+
+        // 2. Try resolving from ScopedServiceRegistry
+        if (_registry.TryGetFactory(targetType, out Func<IPacketScope, object>? factory) && factory is not null)
+        {
+            object instance = factory(this);
+
+            if (instance is IAsyncDisposable asyncDisp)
+            {
+                this.RegisterForDisposal(asyncDisp);
+            }
+            else if (instance is IDisposable syncDisp)
+            {
+                this.RegisterForDisposal(syncDisp);
+            }
+
+            this.AddResolved(targetType, instance);
+            return (T)instance;
+        }
+
+        // 3. Fallback: resolve from Singleton InstanceManager
+        T? singleton = InstanceManager.Instance.GetExistingInstance<T>();
+        if (singleton is not null)
+        {
+            return singleton;
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void RegisterForDisposal(IDisposable disposable)
+    {
+        if (disposable is null)
+        {
+            return;
+        }
+
+        if (_disposablesCount >= _disposables.Length)
+        {
+            Array.Resize(ref _disposables, _disposables.Length * 2);
+        }
+
+        _disposables[_disposablesCount++] = disposable;
+    }
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void RegisterForDisposal(IAsyncDisposable asyncDisposable)
+    {
+        if (asyncDisposable is null)
+        {
+            return;
+        }
+
+        if (_asyncDisposablesCount >= _asyncDisposables.Length)
+        {
+            Array.Resize(ref _asyncDisposables, _asyncDisposables.Length * 2);
+        }
+
+        _asyncDisposables[_asyncDisposablesCount++] = asyncDisposable;
+    }
+
+    private void AddResolved(Type type, object instance)
+    {
+        if (_resolvedCount >= _resolved.Length)
+        {
+            Array.Resize(ref _resolved, _resolved.Length * 2);
+        }
+
+        _resolved[_resolvedCount++] = (type, instance);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        // 1. Dispose async disposables in LIFO order
+        for (int i = _asyncDisposablesCount - 1; i >= 0; i--)
+        {
+            try
+            {
+                await _asyncDisposables[i].DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
+            {
+                // Preserve execution integrity
+            }
+            finally
+            {
+                _asyncDisposables[i] = null!;
+            }
+        }
+        _asyncDisposablesCount = 0;
+
+        // 2. Dispose synchronous disposables in LIFO order
+        for (int i = _disposablesCount - 1; i >= 0; i--)
+        {
+            try
+            {
+                _disposables[i].Dispose();
+            }
+            catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
+            {
+            }
+            finally
+            {
+                _disposables[i] = null!;
+            }
+        }
+        _disposablesCount = 0;
+
+        // 3. Clear resolved references
+        for (int i = 0; i < _resolvedCount; i++)
+        {
+            _resolved[i] = default;
+        }
+        _resolvedCount = 0;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        // 1. Dispose async disposables in LIFO order (prefer sync Dispose if implemented)
+        for (int i = _asyncDisposablesCount - 1; i >= 0; i--)
+        {
+            try
+            {
+                if (_asyncDisposables[i] is IDisposable syncDisposable)
+                {
+                    syncDisposable.Dispose();
+                }
+                else
+                {
+                    _asyncDisposables[i].DisposeAsync().AsTask().GetAwaiter().GetResult();
+                }
+            }
+            catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
+            {
+            }
+            finally
+            {
+                _asyncDisposables[i] = null!;
+            }
+        }
+        _asyncDisposablesCount = 0;
+
+        // 2. Dispose synchronous disposables in LIFO order
+        for (int i = _disposablesCount - 1; i >= 0; i--)
+        {
+            try
+            {
+                _disposables[i].Dispose();
+            }
+            catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
+            {
+            }
+            finally
+            {
+                _disposables[i] = null!;
+            }
+        }
+        _disposablesCount = 0;
+
+        // 3. Clear resolved references
+        for (int i = 0; i < _resolvedCount; i++)
+        {
+            _resolved[i] = default;
+        }
+        _resolvedCount = 0;
+    }
+
+    /// <inheritdoc/>
+    public void ResetForPool()
+    {
+        this.Dispose();
+        Volatile.Write(ref _disposed, 0);
+    }
+}

--- a/src/Nalix.Runtime/Dispatching/PacketScope.cs
+++ b/src/Nalix.Runtime/Dispatching/PacketScope.cs
@@ -26,11 +26,8 @@ public sealed class PacketScope : IPacketScope, IPoolable, IDisposable, IAsyncDi
     private (Type Type, object Instance)[] _resolved = new (Type, object)[InitialCapacity];
     private int _resolvedCount;
 
-    private IDisposable[] _disposables = new IDisposable[InitialDisposableCapacity];
+    private object[] _disposables = new object[InitialDisposableCapacity];
     private int _disposablesCount;
-
-    private IAsyncDisposable[] _asyncDisposables = new IAsyncDisposable[InitialDisposableCapacity];
-    private int _asyncDisposablesCount;
 
     private int _disposed;
 
@@ -130,12 +127,12 @@ public sealed class PacketScope : IPacketScope, IPoolable, IDisposable, IAsyncDi
             return;
         }
 
-        if (_asyncDisposablesCount >= _asyncDisposables.Length)
+        if (_disposablesCount >= _disposables.Length)
         {
-            Array.Resize(ref _asyncDisposables, _asyncDisposables.Length * 2);
+            Array.Resize(ref _disposables, _disposables.Length * 2);
         }
 
-        _asyncDisposables[_asyncDisposablesCount++] = asyncDisposable;
+        _disposables[_disposablesCount++] = asyncDisposable;
     }
 
     private void AddResolved(Type type, object instance)
@@ -156,42 +153,31 @@ public sealed class PacketScope : IPacketScope, IPoolable, IDisposable, IAsyncDi
             return;
         }
 
-        // 1. Dispose async disposables in LIFO order
-        for (int i = _asyncDisposablesCount - 1; i >= 0; i--)
+        // 1. Unwind single disposables stack in strict LIFO order
+        for (int i = _disposablesCount - 1; i >= 0; i--)
         {
+            object item = _disposables[i];
+            _disposables[i] = null!;
+
             try
             {
-                await _asyncDisposables[i].DisposeAsync().ConfigureAwait(false);
+                if (item is IAsyncDisposable asyncDisp)
+                {
+                    await asyncDisp.DisposeAsync().ConfigureAwait(false);
+                }
+                else if (item is IDisposable syncDisp)
+                {
+                    syncDisp.Dispose();
+                }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
                 // Preserve execution integrity
             }
-            finally
-            {
-                _asyncDisposables[i] = null!;
-            }
-        }
-        _asyncDisposablesCount = 0;
-
-        // 2. Dispose synchronous disposables in LIFO order
-        for (int i = _disposablesCount - 1; i >= 0; i--)
-        {
-            try
-            {
-                _disposables[i].Dispose();
-            }
-            catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
-            {
-            }
-            finally
-            {
-                _disposables[i] = null!;
-            }
         }
         _disposablesCount = 0;
 
-        // 3. Clear resolved references
+        // 2. Clear resolved references
         for (int i = 0; i < _resolvedCount; i++)
         {
             _resolved[i] = default;
@@ -207,48 +193,30 @@ public sealed class PacketScope : IPacketScope, IPoolable, IDisposable, IAsyncDi
             return;
         }
 
-        // 1. Dispose async disposables in LIFO order (prefer sync Dispose if implemented)
-        for (int i = _asyncDisposablesCount - 1; i >= 0; i--)
+        // 1. Unwind single disposables stack in strict LIFO order
+        for (int i = _disposablesCount - 1; i >= 0; i--)
         {
+            object item = _disposables[i];
+            _disposables[i] = null!;
+
             try
             {
-                if (_asyncDisposables[i] is IDisposable syncDisposable)
+                if (item is IDisposable syncDisposable)
                 {
                     syncDisposable.Dispose();
                 }
-                else
+                else if (item is IAsyncDisposable asyncDisp)
                 {
-                    _asyncDisposables[i].DisposeAsync().AsTask().GetAwaiter().GetResult();
+                    asyncDisp.DisposeAsync().AsTask().GetAwaiter().GetResult();
                 }
             }
             catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
             {
-            }
-            finally
-            {
-                _asyncDisposables[i] = null!;
-            }
-        }
-        _asyncDisposablesCount = 0;
-
-        // 2. Dispose synchronous disposables in LIFO order
-        for (int i = _disposablesCount - 1; i >= 0; i--)
-        {
-            try
-            {
-                _disposables[i].Dispose();
-            }
-            catch (Exception ex) when (ExceptionClassifier.IsNonFatal(ex))
-            {
-            }
-            finally
-            {
-                _disposables[i] = null!;
             }
         }
         _disposablesCount = 0;
 
-        // 3. Clear resolved references
+        // 2. Clear resolved references
         for (int i = 0; i < _resolvedCount; i++)
         {
             _resolved[i] = default;

--- a/src/Nalix.Runtime/Routing/ScopedServiceRegistry.cs
+++ b/src/Nalix.Runtime/Routing/ScopedServiceRegistry.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Concurrent;
+using Nalix.Abstractions.Injection;
+
+namespace Nalix.Runtime.Routing;
+
+/// <summary>
+/// Thread-safe registry that maps service types to their per-packet factory delegates.
+/// </summary>
+public sealed class ScopedServiceRegistry
+{
+    private static readonly Lazy<ScopedServiceRegistry> s_instance = new(() => new ScopedServiceRegistry(), isThreadSafe: true);
+
+    /// <summary>
+    /// Gets the shared global registry instance.
+    /// </summary>
+    public static ScopedServiceRegistry Instance => s_instance.Value;
+
+    private readonly ConcurrentDictionary<Type, Func<IPacketScope, object>> _factories = new();
+
+    /// <summary>
+    /// Registers a factory for a scoped service of type <typeparamref name="TService"/>.
+    /// </summary>
+    /// <typeparam name="TService">The service contract type.</typeparam>
+    /// <param name="factory">The factory that creates an instance using the active packet scope.</param>
+    public void RegisterScoped<TService>(Func<IPacketScope, TService> factory) where TService : class
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        _factories[typeof(TService)] = scope => factory(scope);
+    }
+
+    /// <summary>
+    /// Registers a factory for a scoped service by explicit service type.
+    /// </summary>
+    /// <param name="serviceType">The service contract type.</param>
+    /// <param name="factory">The factory that creates an instance using the active packet scope.</param>
+    public void RegisterScoped(Type serviceType, Func<IPacketScope, object> factory)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+        ArgumentNullException.ThrowIfNull(factory);
+        _factories[serviceType] = factory;
+    }
+
+    /// <summary>
+    /// Attempts to retrieve a registered factory for the specified service type.
+    /// </summary>
+    /// <param name="serviceType">The service contract type.</param>
+    /// <param name="factory">The factory if found; otherwise, null.</param>
+    /// <returns>True if a factory is registered; otherwise, false.</returns>
+    public bool TryGetFactory(Type serviceType, out Func<IPacketScope, object>? factory)
+        => _factories.TryGetValue(serviceType, out factory);
+
+    /// <summary>
+    /// Clears all registered scoped factories.
+    /// </summary>
+    public void Clear() => _factories.Clear();
+}

--- a/tests/Nalix.Analyzers.Tests/CustomControllerAnalyzerTests.cs
+++ b/tests/Nalix.Analyzers.Tests/CustomControllerAnalyzerTests.cs
@@ -149,6 +149,58 @@ public sealed class LoginPacket : Nalix.Codec.DataFrames.PacketBase<LoginPacket>
             "NALIX038");
     }
 
+    [Fact]
+    public async Task FromScopeParameter_IsValid_ProducesNoDiagnostic()
+    {
+        const string source = """
+namespace Demo;
+using Nalix.Abstractions.Networking.Packets;
+using Nalix.Abstractions.Injection;
+
+public interface IMyService { }
+
+[PacketHandler]
+public sealed class MyController
+{
+    [PacketOpcode(0x0200)]
+    public void Handle(Nalix.Runtime.Dispatching.PacketContext<LoginPacket> context, [FromScope] IMyService service) { }
+}
+
+public sealed class LoginPacket : Nalix.Codec.DataFrames.PacketBase<LoginPacket>
+{
+    public static new LoginPacket Deserialize(ReadOnlySpan<byte> buffer) => PacketBase<LoginPacket>.Deserialize(buffer);
+}
+""";
+
+        await Verifier<CodeFixes.PacketOpcodeCodeFixProvider>.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ExtraParameter_WithoutFromScope_ProducesNALIX003()
+    {
+        const string source = """
+namespace Demo;
+using Nalix.Abstractions.Networking.Packets;
+
+public interface IMyService { }
+
+[PacketHandler]
+public sealed class MyController
+{
+    [PacketOpcode(0x0200)]
+    public void Handle(Nalix.Runtime.Dispatching.PacketContext<LoginPacket> context, IMyService service) { }
+}
+
+public sealed class LoginPacket : Nalix.Codec.DataFrames.PacketBase<LoginPacket>
+{
+    public static new LoginPacket Deserialize(ReadOnlySpan<byte> buffer) => PacketBase<LoginPacket>.Deserialize(buffer);
+}
+""";
+
+        await Verifier<CodeFixes.PacketOpcodeCodeFixProvider>.VerifyAnalyzerAsync(
+            source,
+            "NALIX003");
+    }
 }
 
 

--- a/tests/Nalix.Analyzers.Tests/CustomControllerAnalyzerTests.cs
+++ b/tests/Nalix.Analyzers.Tests/CustomControllerAnalyzerTests.cs
@@ -201,6 +201,32 @@ public sealed class LoginPacket : Nalix.Codec.DataFrames.PacketBase<LoginPacket>
             source,
             "NALIX003");
     }
+
+    [Fact]
+    public async Task ValueTypeParameter_WithFromScope_ProducesNALIX003()
+    {
+        const string source = """
+namespace Demo;
+using Nalix.Abstractions.Networking.Packets;
+using Nalix.Abstractions.Injection;
+
+[PacketHandler]
+public sealed class MyController
+{
+    [PacketOpcode(0x0200)]
+    public void Handle(Nalix.Runtime.Dispatching.PacketContext<LoginPacket> context, [FromScope] int invalidValueType) { }
+}
+
+public sealed class LoginPacket : Nalix.Codec.DataFrames.PacketBase<LoginPacket>
+{
+    public static new LoginPacket Deserialize(ReadOnlySpan<byte> buffer) => PacketBase<LoginPacket>.Deserialize(buffer);
+}
+""";
+
+        await Verifier<CodeFixes.PacketOpcodeCodeFixProvider>.VerifyAnalyzerAsync(
+            source,
+            "NALIX003");
+    }
 }
 
 

--- a/tests/Nalix.Analyzers.Tests/TestSources.cs
+++ b/tests/Nalix.Analyzers.Tests/TestSources.cs
@@ -61,6 +61,12 @@ namespace Nalix.Abstractions.Middleware
     }
 }
 
+namespace Nalix.Abstractions.Injection
+{
+    public interface IPacketScope : IDisposable, IAsyncDisposable { }
+    public sealed class FromScopeAttribute : Attribute { }
+}
+
 namespace Nalix.Abstractions
 {
     public interface IBufferLease { }
@@ -115,6 +121,7 @@ namespace Nalix.Runtime.Dispatching
     {
         public TPacket Packet => default!;
         public IConnection Connection => null!;
+        public Nalix.Abstractions.Injection.IPacketScope Scope => null!;
         public CancellationToken CancellationToken => default;
     }
 

--- a/tests/Nalix.Runtime.Tests/PacketHandlerGeneratorBehaviorTests.cs
+++ b/tests/Nalix.Runtime.Tests/PacketHandlerGeneratorBehaviorTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nalix.Abstractions;
+using Nalix.Abstractions.Injection;
 using Nalix.Abstractions.Networking;
 using Nalix.Abstractions.Networking.Packets;
 using Nalix.Abstractions.Networking.Protocols;
@@ -168,6 +169,44 @@ public sealed class PacketHandlerGeneratorBehaviorTests
 
         resolved.Should().BeFalse("a 2-parameter handler is not a supported shape and must not be registered; " +
             "NalixUsageAnalyzer reports NALIX003 for this signature at compile time");
+    }
+
+    [Fact]
+    public async Task FromScopeHandler_ResolvesServiceAndExecutesSuccessfully()
+    {
+        EchoController controller = new();
+        PacketDispatchOptions<EchoPacket> options = BuildDispatcher(controller);
+        FakeConnection connection = new();
+
+        TestScopedEchoService service = new();
+        ScopedServiceRegistry.Instance.RegisterScoped<IScopedEchoService>(_ => service);
+
+        _ = options.TryResolveHandler(EchoController.FromScopeOpCode, out PacketHandler<EchoPacket> descriptor);
+        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.FromScopeOpCode), connection, reliable: true, encryptedOnWire: false);
+
+        controller.FromScopeInvoked.Should().BeTrue();
+        controller.InjectedService.Should().BeSameAs(service);
+        connection.FakeTcp.SentMessages.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task MultipleFromScopeHandler_ResolvesAllServicesInOrder()
+    {
+        EchoController controller = new();
+        PacketDispatchOptions<EchoPacket> options = BuildDispatcher(controller);
+        FakeConnection connection = new();
+
+        TestScopedEchoService service1 = new();
+        TestScopedEchoService2 service2 = new();
+        ScopedServiceRegistry.Instance.RegisterScoped<IScopedEchoService>(_ => service1);
+        ScopedServiceRegistry.Instance.RegisterScoped<IScopedEchoService2>(_ => service2);
+
+        _ = options.TryResolveHandler(EchoController.MultipleFromScopeOpCode, out PacketHandler<EchoPacket> descriptor);
+        await options.ExecuteResolvedHandlerAsync(descriptor, MakePacket(EchoController.MultipleFromScopeOpCode), connection, reliable: true, encryptedOnWire: false);
+
+        controller.FromScopeInvoked.Should().BeTrue();
+        controller.InjectedService.Should().BeSameAs(service1);
+        controller.InjectedService2.Should().BeSameAs(service2);
     }
 
     private sealed class FakeSequenceCounter : ISequenceCounter
@@ -333,4 +372,54 @@ public sealed class EchoController
     // silently skips this — no diagnostic, no registration — per PacketHandlerGenerator.cs:243.
     [PacketOpcode(TwoParamOpCode)]
     public void HandleTwoParam(EchoPacket packet, IConnection connection) => VoidInvoked = true;
+
+    public const ushort FromScopeOpCode = 0x2109;
+    public const ushort MultipleFromScopeOpCode = 0x210A;
+
+    public bool FromScopeInvoked { get; private set; }
+    public IScopedEchoService? InjectedService { get; private set; }
+    public IScopedEchoService2? InjectedService2 { get; private set; }
+
+    [PacketOpcode(FromScopeOpCode)]
+    public async ValueTask<EchoPacket> HandleFromScope(
+        IPacketContext<EchoPacket> context,
+        [FromScope] IScopedEchoService service)
+    {
+        FromScopeInvoked = true;
+        InjectedService = service;
+        await Task.Yield();
+        return new EchoPacket { Header = new PacketHeader { OpCode = FromScopeOpCode, SequenceId = context.Packet.Header.SequenceId } };
+    }
+
+    [PacketOpcode(MultipleFromScopeOpCode)]
+    public async ValueTask HandleMultipleFromScope(
+        IPacketContext<EchoPacket> context,
+        [FromScope] IScopedEchoService service1,
+        [FromScope] IScopedEchoService2 service2)
+    {
+        FromScopeInvoked = true;
+        InjectedService = service1;
+        InjectedService2 = service2;
+        await Task.Yield();
+    }
+}
+
+public interface IScopedEchoService
+{
+    Guid Id { get; }
+}
+
+public sealed class TestScopedEchoService : IScopedEchoService
+{
+    public Guid Id { get; } = Guid.NewGuid();
+}
+
+public interface IScopedEchoService2
+{
+    Guid Id { get; }
+}
+
+public sealed class TestScopedEchoService2 : IScopedEchoService2
+{
+    public Guid Id { get; } = Guid.NewGuid();
 }

--- a/tests/Nalix.Runtime.Tests/PacketScopeTests.cs
+++ b/tests/Nalix.Runtime.Tests/PacketScopeTests.cs
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 PPN Corporation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Nalix.Abstractions.Injection;
+using Nalix.Framework.Injection;
+using Nalix.Runtime.Dispatching;
+using Nalix.Runtime.Routing;
+using Xunit;
+
+namespace Nalix.Runtime.Tests;
+
+public sealed class PacketScopeTests
+{
+    private interface ITestScopedService
+    {
+        Guid Id { get; }
+    }
+
+    private sealed class TestScopedService : ITestScopedService, IDisposable, IAsyncDisposable
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+        public bool IsDisposedSync { get; private set; }
+        public bool IsDisposedAsync { get; private set; }
+        public List<string>? Log { get; set; }
+
+        public void Dispose()
+        {
+            this.IsDisposedSync = true;
+            this.Log?.Add($"Sync:{this.Id}");
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            this.IsDisposedAsync = true;
+            this.Log?.Add($"Async:{this.Id}");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class SingletonService
+    {
+        public string Name { get; set; } = "Singleton";
+    }
+
+    [Fact]
+    public void Resolve_RegisteredScopedService_ReturnsSameInstanceWithinSameScope()
+    {
+        ScopedServiceRegistry registry = new();
+        registry.RegisterScoped<ITestScopedService>(scope => new TestScopedService());
+
+        using PacketScope scope = new(registry);
+
+        ITestScopedService first = scope.GetRequiredService<ITestScopedService>();
+        ITestScopedService second = scope.GetRequiredService<ITestScopedService>();
+
+        first.Should().NotBeNull();
+        second.Should().NotBeNull();
+        first.Should().BeSameAs(second);
+        first.Id.Should().Be(second.Id);
+    }
+
+    [Fact]
+    public void Resolve_DifferentScopes_ReturnsDifferentInstances()
+    {
+        ScopedServiceRegistry registry = new();
+        registry.RegisterScoped<ITestScopedService>(scope => new TestScopedService());
+
+        using PacketScope scope1 = new(registry);
+        using PacketScope scope2 = new(registry);
+
+        ITestScopedService first = scope1.GetRequiredService<ITestScopedService>();
+        ITestScopedService second = scope2.GetRequiredService<ITestScopedService>();
+
+        first.Should().NotBeSameAs(second);
+        first.Id.Should().NotBe(second.Id);
+    }
+
+    [Fact]
+    public void Resolve_FallbackToSingleton_WhenNotRegisteredInScope()
+    {
+        ScopedServiceRegistry registry = new();
+        SingletonService singleton = new() { Name = "GlobalSingleton" };
+        InstanceManager.Instance.Register<SingletonService>(singleton);
+
+        try
+        {
+            using PacketScope scope = new(registry);
+            SingletonService resolved = scope.GetRequiredService<SingletonService>();
+
+            resolved.Should().NotBeNull();
+            resolved.Should().BeSameAs(singleton);
+        }
+        finally
+        {
+            _ = InstanceManager.Instance.RemoveInstance(typeof(SingletonService));
+        }
+    }
+
+    [Fact]
+    public void Resolve_UnregisteredService_ThrowsInvalidOperationException()
+    {
+        ScopedServiceRegistry registry = new();
+        using PacketScope scope = new(registry);
+
+        Action act = () => scope.GetRequiredService<ITestScopedService>();
+
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*No service for type*");
+    }
+
+    [Fact]
+    public void GetService_UnregisteredService_ReturnsNull()
+    {
+        ScopedServiceRegistry registry = new();
+        using PacketScope scope = new(registry);
+
+        ITestScopedService? resolved = scope.GetService<ITestScopedService>();
+
+        resolved.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisposesDisposablesInLifoOrder()
+    {
+        ScopedServiceRegistry registry = new();
+        List<string> disposalLog = [];
+
+        TestScopedService s1 = new() { Log = disposalLog };
+        TestScopedService s2 = new() { Log = disposalLog };
+
+        PacketScope scope = new(registry);
+        scope.RegisterForDisposal((IAsyncDisposable)s1);
+        scope.RegisterForDisposal((IAsyncDisposable)s2);
+
+        await scope.DisposeAsync();
+
+        s1.IsDisposedAsync.Should().BeTrue();
+        s2.IsDisposedAsync.Should().BeTrue();
+
+        // LIFO order: s2 was registered last, so it must be disposed first
+        disposalLog.Should().ContainInOrder($"Async:{s2.Id}", $"Async:{s1.Id}");
+    }
+
+    [Fact]
+    public void Dispose_DisposesDisposablesInLifoOrder_AndPrefersSyncDispose()
+    {
+        ScopedServiceRegistry registry = new();
+        List<string> disposalLog = [];
+
+        TestScopedService s1 = new() { Log = disposalLog };
+        TestScopedService s2 = new() { Log = disposalLog };
+
+        PacketScope scope = new(registry);
+        scope.RegisterForDisposal((IAsyncDisposable)s1);
+        scope.RegisterForDisposal((IAsyncDisposable)s2);
+
+        scope.Dispose();
+
+        s1.IsDisposedSync.Should().BeTrue();
+        s2.IsDisposedSync.Should().BeTrue();
+
+        // LIFO order: s2 was registered last, so it must be disposed first
+        disposalLog.Should().ContainInOrder($"Sync:{s2.Id}", $"Sync:{s1.Id}");
+    }
+
+    [Fact]
+    public void ResetForPool_ClearsResolvedServicesAndAllowsReUse()
+    {
+        ScopedServiceRegistry registry = new();
+        registry.RegisterScoped<ITestScopedService>(scope => new TestScopedService());
+
+        PacketScope scope = new(registry);
+
+        ITestScopedService first = scope.GetRequiredService<ITestScopedService>();
+        Guid firstId = first.Id;
+
+        // Reset for pool
+        scope.ResetForPool();
+
+        // Rent again
+        ITestScopedService second = scope.GetRequiredService<ITestScopedService>();
+        Guid secondId = second.Id;
+
+        firstId.Should().NotBe(secondId);
+        ((TestScopedService)first).IsDisposedSync.Should().BeTrue();
+    }
+}

--- a/tests/Nalix.Runtime.Tests/PacketScopeTests.cs
+++ b/tests/Nalix.Runtime.Tests/PacketScopeTests.cs
@@ -41,6 +41,19 @@ public sealed class PacketScopeTests
         }
     }
 
+    private sealed class SyncOnlyScopedService : IDisposable
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+        public bool IsDisposedSync { get; private set; }
+        public List<string>? Log { get; set; }
+
+        public void Dispose()
+        {
+            this.IsDisposedSync = true;
+            this.Log?.Add($"Sync:{this.Id}");
+        }
+    }
+
     private sealed class SingletonService
     {
         public string Name { get; set; } = "Singleton";
@@ -165,6 +178,30 @@ public sealed class PacketScopeTests
 
         // LIFO order: s2 was registered last, so it must be disposed first
         disposalLog.Should().ContainInOrder($"Sync:{s2.Id}", $"Sync:{s1.Id}");
+    }
+
+    [Fact]
+    public async Task DisposeAsync_MixedSyncAndAsync_PreservesStrictLifoOrder()
+    {
+        ScopedServiceRegistry registry = new();
+        List<string> disposalLog = [];
+
+        TestScopedService s1Async = new() { Log = disposalLog };
+        SyncOnlyScopedService s2Sync = new() { Log = disposalLog };
+
+        PacketScope scope = new(registry);
+        // Register async first, sync second
+        scope.RegisterForDisposal((IAsyncDisposable)s1Async);
+        scope.RegisterForDisposal((IDisposable)s2Sync);
+
+        await scope.DisposeAsync();
+
+        s1Async.IsDisposedAsync.Should().BeTrue();
+        s2Sync.IsDisposedSync.Should().BeTrue();
+
+        // Strict LIFO: s2Sync was registered second, so it MUST be disposed first!
+        disposalLog[0].Should().Be($"Sync:{s2Sync.Id}");
+        disposalLog[1].Should().Be($"Async:{s1Async.Id}");
     }
 
     [Fact]

--- a/tests/Nalix.Runtime.Tests/PolicyRateLimiterTests.cs
+++ b/tests/Nalix.Runtime.Tests/PolicyRateLimiterTests.cs
@@ -146,6 +146,7 @@ public sealed class PolicyRateLimiterTests : IDisposable
                 transport: null);
 
         public IPacketSender Sender => null!;
+        public Nalix.Abstractions.Injection.IPacketScope Scope => null!;
         public CancellationToken CancellationToken => CancellationToken.None;
         public void ResetForPool() { }
     }


### PR DESCRIPTION
Introduces a per-packet dependency injection system for packet handlers:
- Adds IPacketScope and PacketScope for scoped service lifetimes and disposal.
- Adds [FromScope] attribute for handler parameters resolved from the scope.
- PacketContext exposes Scope; lifecycle managed with context.
- Updates generator and analyzer to support [FromScope] parameters.
- Adds ScopedServiceRegistry and RegisterScoped API.
- Includes comprehensive tests and updates diagnostics/docs for new handler signature.